### PR TITLE
Improve performance in `Map.Update`

### DIFF
--- a/Core.Tests/CommandTests.cs
+++ b/Core.Tests/CommandTests.cs
@@ -34,7 +34,7 @@ using Weikio.PluginFramework.Catalogs;
 using Xunit;
 using Xunit.Abstractions;
 
-// cannot cast MockedGameConnection to IGameConnection ??? 
+// cannot cast MockedGameConnection to IGameConnection ???
 #pragma warning disable CS8602
 
 namespace Core.Tests;
@@ -51,7 +51,6 @@ internal class MockedGameConnection : IGameConnection
     public void Close()
     {
     }
-    
 
     public Task Send<T>(T packet) where T : IPacketSerializable
     {
@@ -91,7 +90,7 @@ public class CommandTests : IAsyncLifetime
     private readonly Faker<Player> _playerDataFaker;
 
     public CommandTests(ITestOutputHelper testOutputHelper)
-    {        
+    {
         _playerDataFaker = new AutoFaker<Player>()
             .RuleFor(x => x.Level, _ => (byte)1)
             .RuleFor(x => x.St, _ => (byte)1)
@@ -122,7 +121,7 @@ public class CommandTests : IAsyncLifetime
         var dbMock = new Mock<IDbConnection>();
         dbMock.SetupDapperAsync(c => c.QueryAsync<Guid>(It.IsAny<string>(), null, null, null, null));
         _services = new ServiceCollection()
-            .AddCoreServices(new EmptyPluginCatalog())
+            .AddCoreServices(new EmptyPluginCatalog(), new ConfigurationBuilder().Build())
             .AddGameServices()
             .AddLogging(x =>
             {
@@ -177,7 +176,7 @@ public class CommandTests : IAsyncLifetime
 
         Assert.NotEmpty(_player.Inventory.Items);
         await _commandManager.Handle(_connection, "/ip");
-        
+
         Assert.Empty(_player.Inventory.Items);
     }
 
@@ -189,12 +188,12 @@ public class CommandTests : IAsyncLifetime
         await world.SpawnEntity(_player);
         await world.SpawnEntity(player2);
         await player2.Move((int)(11 * Map.MapUnit), (int)(27 * Map.MapUnit));
-        
+
         Assert.Equal((int)(10 * Map.MapUnit), _player.PositionX);
         Assert.Equal((int)(26 * Map.MapUnit), _player.PositionY);
-        
+
         await _commandManager.Handle(_connection, $"/tp \"{player2.Name}\"");
-        
+
         Assert.Equal((int)(11 * Map.MapUnit), _player.PositionX);
         Assert.Equal((int)(27 * Map.MapUnit), _player.PositionY);
     }
@@ -207,11 +206,11 @@ public class CommandTests : IAsyncLifetime
         await world.SpawnEntity(_player);
         await world.SpawnEntity(player2);
         await player2.Move((int)(11 * Map.MapUnit), (int)(27 * Map.MapUnit));
-        
-        
+
+
         Assert.Equal((int)(11 * Map.MapUnit), player2.PositionX);
         Assert.Equal((int)(27 * Map.MapUnit), player2.PositionY);
-        
+
         await _commandManager.Handle(_connection, $"/tphere \"{player2.Name}\"");
 
         Assert.Equal((int)(10 * Map.MapUnit), player2.PositionX);
@@ -247,7 +246,7 @@ public class CommandTests : IAsyncLifetime
         var player2 = ActivatorUtilities.CreateInstance<PlayerEntity>(_services, _playerDataFaker.Generate());
         await world.SpawnEntity(_player);
         await world.SpawnEntity(player2);
-        
+
         await _commandManager.Handle(_connection, $"/exp 500 \"{player2.Name}\"");
 
         player2.GetPoint(EPoints.Experience).Should().Be(500);
@@ -273,7 +272,7 @@ public class CommandTests : IAsyncLifetime
         var player2 = ActivatorUtilities.CreateInstance<PlayerEntity>(_services, _playerDataFaker.Generate());
         await world.SpawnEntity(_player);
         await world.SpawnEntity(player2);
-        
+
         await _commandManager.Handle(_connection, $"/give \"{player2.Name}\" 1 10");
 
         player2.Inventory.Items.Should().NotBeEmpty();
@@ -300,7 +299,7 @@ public class CommandTests : IAsyncLifetime
         var player2 = ActivatorUtilities.CreateInstance<PlayerEntity>(_services, _playerDataFaker.Generate());
         await world.SpawnEntity(_player);
         await world.SpawnEntity(player2);
-        
+
         player2.GetPoint(EPoints.Gold).Should().Be(0);
         await _commandManager.Handle(_connection, $"/gold 10 \"{player2.Name}\"");
         player2.GetPoint(EPoints.Gold).Should().Be(10);
@@ -316,7 +315,7 @@ public class CommandTests : IAsyncLifetime
 
         Assert.Equal((int)(10 * Map.MapUnit), _player.PositionX);
         Assert.Equal((int)(26 * Map.MapUnit), _player.PositionY);
-        
+
         await _commandManager.Handle(_connection, $"/goto {11} {27}");
 
         Assert.Equal((int)(_player.Map.PositionX + 11 * 100), _player.PositionX);
@@ -328,11 +327,11 @@ public class CommandTests : IAsyncLifetime
     {
         var world = await PrepareWorldAsync();
         await world.SpawnEntity(_player);
-        
-        
+
+
         Assert.Equal((int)(10 * Map.MapUnit), _player.PositionX);
         Assert.Equal((int)(26 * Map.MapUnit), _player.PositionY);
-        
+
         await _commandManager.Handle(_connection, "/goto --map map_b2");
 
         // target position is half of X & Y
@@ -363,7 +362,7 @@ public class CommandTests : IAsyncLifetime
         await world.SpawnEntity(player2);
 
         await _commandManager.Handle(_connection, $"/kick \"{player2.Name}\"");
-        
+
         Assert.Null(world.GetPlayer(player2.Name));
     }
 
@@ -382,7 +381,7 @@ public class CommandTests : IAsyncLifetime
     public async Task LevelCommand_Self()
     {
         _player.GetPoint(EPoints.Level).Should().Be(1);
-        
+
         await _commandManager.Handle(_connection, "/level 30");
 
         _player.GetPoint(EPoints.Level).Should().Be(30);
@@ -397,7 +396,7 @@ public class CommandTests : IAsyncLifetime
         await world.SpawnEntity(player2);
 
         player2.GetPoint(EPoints.Level).Should().Be(1);
-        
+
         await _commandManager.Handle(_connection, $"/level 30 \"{player2.Name}\"");
 
         player2.GetPoint(EPoints.Level).Should().Be(30);
@@ -408,9 +407,9 @@ public class CommandTests : IAsyncLifetime
     {
         var world = await PrepareWorldAsync();
         await world.SpawnEntity(_player);
-        
+
         world.GetPlayer(_player.Name).Should().NotBeNull();
-        
+
         await _commandManager.Handle(_connection, "/logout");
 
         world.GetPlayer(_player.Name).Should().BeNull();
@@ -421,13 +420,13 @@ public class CommandTests : IAsyncLifetime
     {
         var world = await PrepareWorldAsync();
         await world.SpawnEntity(_player);
-        
+
         world.GetPlayer(_player.Name).Should().NotBeNull();
         (_connection as MockedGameConnection).SentPhases.Should().NotContainEquivalentOf(new GCPhase
         {
             Phase = EPhases.Select
         });
-        
+
         await _commandManager.Handle(_connection, "/phase_select");
 
         _player.Connection.Phase.Should().Be(EPhases.Select);
@@ -443,9 +442,9 @@ public class CommandTests : IAsyncLifetime
     {
         var world = await PrepareWorldAsync();
         await world.SpawnEntity(_player);
-        
+
         world.GetPlayer(_player.Name).Should().NotBeNull();
-        
+
         await _commandManager.Handle(_connection, "/quit");
 
         world.GetPlayer(_player.Name).Should().BeNull();
@@ -473,7 +472,7 @@ public class CommandTests : IAsyncLifetime
         _player.Map.GetEntities().Count.Should().Be(1);
 
         await _commandManager.Handle(_connection, "/spawn 101");
-        
+
         _player.Map.GetEntities().Count.Should().Be(2);
     }
 
@@ -487,7 +486,7 @@ public class CommandTests : IAsyncLifetime
         _player.Map.GetEntities().Count.Should().Be(1);
 
         await _commandManager.Handle(_connection, "/spawn 101 10");
-        
+
         _player.Map.GetEntities().Count.Should().Be(11);
     }
 
@@ -496,9 +495,9 @@ public class CommandTests : IAsyncLifetime
     {
         await _player.AddPoint(EPoints.StatusPoints, 1);
         _player.GetPoint(EPoints.Ht).Should().Be(1);
-        
+
         await _commandManager.Handle(_connection, "/stat ht");
-        
+
         _player.GetPoint(EPoints.Ht).Should().Be(2);
     }
 

--- a/Core.Tests/CommandTests.cs
+++ b/Core.Tests/CommandTests.cs
@@ -52,7 +52,7 @@ internal class MockedGameConnection : IGameConnection
     {
     }
 
-    public Task Send<T>(T packet) where T : IPacketSerializable
+    public void Send<T>(T packet) where T : IPacketSerializable
     {
         // ReSharper disable once SuspiciousTypeConversion.Global
         if (packet is ChatOutcoming chat)
@@ -62,8 +62,6 @@ internal class MockedGameConnection : IGameConnection
         {
             SentPhases.Add(phase);
         }
-
-        return Task.CompletedTask;
     }
 
     public Task StartAsync(CancellationToken token = default)
@@ -185,9 +183,9 @@ public class CommandTests : IAsyncLifetime
     {
         var world = await PrepareWorldAsync();
         var player2 = ActivatorUtilities.CreateInstance<PlayerEntity>(_services, _playerDataFaker.Generate());
-        await world.SpawnEntity(_player);
-        await world.SpawnEntity(player2);
-        await player2.Move((int)(11 * Map.MapUnit), (int)(27 * Map.MapUnit));
+        world.SpawnEntity(_player);
+        world.SpawnEntity(player2);
+        player2.Move((int)(11 * Map.MapUnit), (int)(27 * Map.MapUnit));
 
         Assert.Equal((int)(10 * Map.MapUnit), _player.PositionX);
         Assert.Equal((int)(26 * Map.MapUnit), _player.PositionY);
@@ -203,9 +201,9 @@ public class CommandTests : IAsyncLifetime
     {
         var world = await PrepareWorldAsync();
         var player2 = ActivatorUtilities.CreateInstance<PlayerEntity>(_services, _playerDataFaker.Generate());
-        await world.SpawnEntity(_player);
-        await world.SpawnEntity(player2);
-        await player2.Move((int)(11 * Map.MapUnit), (int)(27 * Map.MapUnit));
+        world.SpawnEntity(_player);
+        world.SpawnEntity(player2);
+        player2.Move((int)(11 * Map.MapUnit), (int)(27 * Map.MapUnit));
 
 
         Assert.Equal((int)(11 * Map.MapUnit), player2.PositionX);
@@ -244,8 +242,8 @@ public class CommandTests : IAsyncLifetime
     {
         var world = await PrepareWorldAsync();
         var player2 = ActivatorUtilities.CreateInstance<PlayerEntity>(_services, _playerDataFaker.Generate());
-        await world.SpawnEntity(_player);
-        await world.SpawnEntity(player2);
+        world.SpawnEntity(_player);
+        world.SpawnEntity(player2);
 
         await _commandManager.Handle(_connection, $"/exp 500 \"{player2.Name}\"");
 
@@ -270,8 +268,8 @@ public class CommandTests : IAsyncLifetime
     {
         var world = await PrepareWorldAsync();
         var player2 = ActivatorUtilities.CreateInstance<PlayerEntity>(_services, _playerDataFaker.Generate());
-        await world.SpawnEntity(_player);
-        await world.SpawnEntity(player2);
+        world.SpawnEntity(_player);
+        world.SpawnEntity(player2);
 
         await _commandManager.Handle(_connection, $"/give \"{player2.Name}\" 1 10");
 
@@ -297,8 +295,8 @@ public class CommandTests : IAsyncLifetime
     {
         var world = await PrepareWorldAsync();
         var player2 = ActivatorUtilities.CreateInstance<PlayerEntity>(_services, _playerDataFaker.Generate());
-        await world.SpawnEntity(_player);
-        await world.SpawnEntity(player2);
+        world.SpawnEntity(_player);
+        world.SpawnEntity(player2);
 
         player2.GetPoint(EPoints.Gold).Should().Be(0);
         await _commandManager.Handle(_connection, $"/gold 10 \"{player2.Name}\"");
@@ -309,9 +307,9 @@ public class CommandTests : IAsyncLifetime
     public async Task GotoCommand_Coords()
     {
         var world = await PrepareWorldAsync();
-        await world.SpawnEntity(_player);
+        world.SpawnEntity(_player);
 
-        await _player.Move((int)(Map.MapUnit * 10), (int)(Map.MapUnit * 26));
+        _player.Move((int)(Map.MapUnit * 10), (int)(Map.MapUnit * 26));
 
         Assert.Equal((int)(10 * Map.MapUnit), _player.PositionX);
         Assert.Equal((int)(26 * Map.MapUnit), _player.PositionY);
@@ -326,7 +324,7 @@ public class CommandTests : IAsyncLifetime
     public async Task GotoCommand_Map()
     {
         var world = await PrepareWorldAsync();
-        await world.SpawnEntity(_player);
+        world.SpawnEntity(_player);
 
 
         Assert.Equal((int)(10 * Map.MapUnit), _player.PositionX);
@@ -358,8 +356,8 @@ public class CommandTests : IAsyncLifetime
     {
         var world = await PrepareWorldAsync();
         var player2 = ActivatorUtilities.CreateInstance<PlayerEntity>(_services, _playerDataFaker.Generate());
-        await world.SpawnEntity(_player);
-        await world.SpawnEntity(player2);
+        world.SpawnEntity(_player);
+        world.SpawnEntity(player2);
 
         await _commandManager.Handle(_connection, $"/kick \"{player2.Name}\"");
 
@@ -392,8 +390,8 @@ public class CommandTests : IAsyncLifetime
     {
         var world = await PrepareWorldAsync();
         var player2 = ActivatorUtilities.CreateInstance<PlayerEntity>(_services, _playerDataFaker.Generate());
-        await world.SpawnEntity(_player);
-        await world.SpawnEntity(player2);
+        world.SpawnEntity(_player);
+        world.SpawnEntity(player2);
 
         player2.GetPoint(EPoints.Level).Should().Be(1);
 
@@ -406,7 +404,7 @@ public class CommandTests : IAsyncLifetime
     public async Task LogoutCommand()
     {
         var world = await PrepareWorldAsync();
-        await world.SpawnEntity(_player);
+        world.SpawnEntity(_player);
 
         world.GetPlayer(_player.Name).Should().NotBeNull();
 
@@ -419,7 +417,7 @@ public class CommandTests : IAsyncLifetime
     public async Task PhaseSelectCommand()
     {
         var world = await PrepareWorldAsync();
-        await world.SpawnEntity(_player);
+        world.SpawnEntity(_player);
 
         world.GetPlayer(_player.Name).Should().NotBeNull();
         (_connection as MockedGameConnection).SentPhases.Should().NotContainEquivalentOf(new GCPhase
@@ -441,7 +439,7 @@ public class CommandTests : IAsyncLifetime
     public async Task QuitCommand()
     {
         var world = await PrepareWorldAsync();
-        await world.SpawnEntity(_player);
+        world.SpawnEntity(_player);
 
         world.GetPlayer(_player.Name).Should().NotBeNull();
 
@@ -466,8 +464,8 @@ public class CommandTests : IAsyncLifetime
     public async Task SpawnCommand_WithoutCount()
     {
         var world = await PrepareWorldAsync();
-        await world.SpawnEntity(_player);
-        await _player.Move((int)(Map.MapUnit * 13), (int)(Map.MapUnit * 29)); // center of the map
+        world.SpawnEntity(_player);
+        _player.Move((int)(Map.MapUnit * 13), (int)(Map.MapUnit * 29)); // center of the map
         await File.WriteAllTextAsync("settings.toml", @"maps = [""map_a2"", ""map_b2""]");
         _player.Map.GetEntities().Count.Should().Be(1);
 
@@ -480,8 +478,8 @@ public class CommandTests : IAsyncLifetime
     public async Task SpawnCommand_WithCount()
     {
         var world = await PrepareWorldAsync();
-        await world.SpawnEntity(_player);
-        await _player.Move((int)(Map.MapUnit * 13), (int)(Map.MapUnit * 29)); // center of the map
+        world.SpawnEntity(_player);
+        _player.Move((int)(Map.MapUnit * 13), (int)(Map.MapUnit * 29)); // center of the map
         await File.WriteAllTextAsync("settings.toml", @"maps = [""map_a2"", ""map_b2""]");
         _player.Map.GetEntities().Count.Should().Be(1);
 
@@ -493,7 +491,7 @@ public class CommandTests : IAsyncLifetime
     [Fact]
     public async Task StatCommand()
     {
-        await _player.AddPoint(EPoints.StatusPoints, 1);
+        _player.AddPoint(EPoints.StatusPoints, 1);
         _player.GetPoint(EPoints.Ht).Should().Be(1);
 
         await _commandManager.Handle(_connection, "/stat ht");

--- a/Core.Tests/CommandTests.cs
+++ b/Core.Tests/CommandTests.cs
@@ -467,11 +467,11 @@ public class CommandTests : IAsyncLifetime
         world.SpawnEntity(_player);
         _player.Move((int)(Map.MapUnit * 13), (int)(Map.MapUnit * 29)); // center of the map
         await File.WriteAllTextAsync("settings.toml", @"maps = [""map_a2"", ""map_b2""]");
-        _player.Map.GetEntities().Count.Should().Be(1);
+        _player.Map.Entities.Count.Should().Be(1);
 
         await _commandManager.Handle(_connection, "/spawn 101");
 
-        _player.Map.GetEntities().Count.Should().Be(2);
+        _player.Map.Entities.Count.Should().Be(2);
     }
 
     [Fact]
@@ -481,11 +481,11 @@ public class CommandTests : IAsyncLifetime
         world.SpawnEntity(_player);
         _player.Move((int)(Map.MapUnit * 13), (int)(Map.MapUnit * 29)); // center of the map
         await File.WriteAllTextAsync("settings.toml", @"maps = [""map_a2"", ""map_b2""]");
-        _player.Map.GetEntities().Count.Should().Be(1);
+        _player.Map.Entities.Count.Should().Be(1);
 
         await _commandManager.Handle(_connection, "/spawn 101 10");
 
-        _player.Map.GetEntities().Count.Should().Be(11);
+        _player.Map.Entities.Count.Should().Be(11);
     }
 
     [Fact]

--- a/Core.Tests/IncomingPacketTests.cs
+++ b/Core.Tests/IncomingPacketTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Text;
 using AutoBogus;
 using FluentAssertions;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using QuantumCore.Core.Packets;
@@ -27,7 +28,7 @@ public class IncomingPacketTests
     public IncomingPacketTests(ITestOutputHelper testOutputHelper)
     {
         var services = new ServiceCollection()
-            .AddCoreServices(new EmptyPluginCatalog())
+            .AddCoreServices(new EmptyPluginCatalog(), new ConfigurationBuilder().Build())
             .AddSingleton<IPacketSerializer, DefaultPacketSerializer>()
             .AddLogging(x =>
             {

--- a/Core.Tests/OutgoingPacketTests.cs
+++ b/Core.Tests/OutgoingPacketTests.cs
@@ -4,6 +4,7 @@ using System.Text;
 using AutoBogus;
 using Bogus;
 using FluentAssertions;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using QuantumCore.Extensions;
@@ -27,7 +28,7 @@ public class OutgoingPacketTests
     public OutgoingPacketTests(ITestOutputHelper testOutputHelper)
     {
         var services = new ServiceCollection()
-            .AddCoreServices(new EmptyPluginCatalog())
+            .AddCoreServices(new EmptyPluginCatalog(), new ConfigurationBuilder().Build())
             .AddSingleton<IPacketSerializer, DefaultPacketSerializer>()
             .AddLogging(x =>
             {
@@ -160,7 +161,7 @@ public class OutgoingPacketTests
                 .Append(obj.Slot)
                 .Concat(BitConverter.GetBytes(obj.Character.Id))
                 .Concat(Encoding.ASCII.GetBytes(obj.Character.Name))
-                .Append((byte)0) // null byte for end of string 
+                .Append((byte)0) // null byte for end of string
                 .Append(obj.Character.Level)
                 .Concat(BitConverter.GetBytes(obj.Character.Playtime))
                 .Append(obj.Character.St)

--- a/Core.Tests/ParserTests.cs
+++ b/Core.Tests/ParserTests.cs
@@ -1,0 +1,213 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using QuantumCore.API.Game.World;
+using QuantumCore.Game.World;
+using Xunit;
+using ParserUtils = QuantumCore.Game.ParserUtils;
+
+namespace Core.Tests;
+
+public class ParserTests
+{
+    [Fact]
+    public void Spawn_Regular()
+    {
+        const string input = "r	751	311	10	10	0	0	5s	100	1	101";
+        var result = ParserUtils.GetSpawnFromLine(input);
+
+        result.Should().BeEquivalentTo(new SpawnPoint
+        {
+            Type = ESpawnPointType.GroupCollection,
+            IsAggressive = false,
+            X = 751,
+            Y = 311,
+            RangeX = 10,
+            RangeY = 10,
+            Direction = 0,
+            MaxAmount = 1,
+            Chance = 100,
+            Monster = 101,
+            RespawnTime = 5
+        });
+    }
+
+    [Fact]
+    public void Spawn_GroupAggressive()
+    {
+        const string input = "ga	188	470	10	10	0	0	0s	100	1	1005";
+        var result = ParserUtils.GetSpawnFromLine(input);
+
+        result.Should().BeEquivalentTo(new SpawnPoint
+        {
+            Type = ESpawnPointType.Group,
+            IsAggressive = true,
+            X = 188,
+            Y = 470,
+            RangeX = 10,
+            RangeY = 10,
+            Direction = 0,
+            MaxAmount = 1,
+            Chance = 100,
+            Monster = 1005,
+            RespawnTime = 0
+        });
+    }
+
+    [Fact]
+    public async Task Group_Regular()
+    {
+        var input = new StringReader("""
+                                       Group	Test
+                                       {
+                                           Vnum	101
+                                           Leader	Test	101
+                                           1	Test	101
+                                           2	Test	101
+                                       }
+                                       """);
+        var result = await ParserUtils.GetSpawnGroupFromBlock(input);
+
+        result.Should().BeEquivalentTo(new SpawnGroup
+        {
+            Name = "Test",
+            Id = 101,
+            Leader = 101,
+            Members =
+            {
+                new SpawnMember { Id = 101 },
+                new SpawnMember { Id = 101 }
+            }
+        });
+    }
+
+    [Fact]
+    public async Task Group_Whitespace()
+    {
+        var input = new StringReader("""
+                                       Group   GroupName
+                                       {
+                                       	Vnum    2430
+                                       		Leader  Leader    2493
+                                       		1   Mob1  2492
+                                       		2   Mob2  2414
+                                       		3   Mob2  2414
+                                       		4   Mob3  2411
+                                       		5   Mob3  2411
+                                       		6   Mob3  2411
+                                       }
+                                       """);
+        var result = await ParserUtils.GetSpawnGroupFromBlock(input);
+
+        result.Should().BeEquivalentTo(new SpawnGroup
+        {
+            Name = "GroupName",
+            Id = 2430,
+            Leader = 2493,
+            Members =
+            {
+                new SpawnMember { Id = 2492 },
+                new SpawnMember { Id = 2414 },
+                new SpawnMember { Id = 2414 },
+                new SpawnMember { Id = 2411 },
+                new SpawnMember { Id = 2411 },
+                new SpawnMember { Id = 2411 }
+            }
+        });
+    }
+
+    [Fact]
+    public async Task GroupCollection_Regular()
+    {
+        var input = new StringReader("""
+                                       Group	a1_01		
+                                       {			
+                                       	Vnum	101	
+                                       	1	101	1
+                                       	2	171	1
+                                       }			
+                                       """);
+        var result = await ParserUtils.GetSpawnGroupCollectionFromBlock(input);
+
+        result.Should().BeEquivalentTo(new SpawnGroupCollection
+        {
+            Name = "a1_01",
+            Id = 101,
+            Members =
+            {
+                new SpawnGroupCollectionMember { Id = 101, Amount = 1 },
+                new SpawnGroupCollectionMember { Id = 171, Amount = 1 }
+            }
+        });
+    }
+
+    [Fact]
+    public async Task GroupCollection_Multiple()
+    {
+        var input = new StringReader("""
+                                       Group	a1_01		
+                                       {			
+                                       	Vnum	101	
+                                       	1	101	1
+                                       	2	171	1
+                                       }			
+                                       			
+                                       Group	a1_02		
+                                       {			
+                                       	Vnum	102	
+                                       	1	102	1
+                                       	2	171	1
+                                       }			
+                                       """);
+        var result = await ParserUtils.GetSpawnGroupCollectionFromBlock(input);
+
+        result.Should().BeEquivalentTo(new SpawnGroupCollection
+        {
+            Name = "a1_01",
+            Id = 101,
+            Members =
+            {
+                new SpawnGroupCollectionMember { Id = 101, Amount = 1 },
+                new SpawnGroupCollectionMember { Id = 171, Amount = 1 }
+            }
+        });
+    }
+
+    [Fact]
+    public async Task GroupCollection_EmptyLines()
+    {
+        var input = new StringReader("""
+                                       Group	a1_01		
+                                       {			
+                                       	Vnum	101	
+                                       	1	101	1
+                                       	2	171	1
+                                       }			
+                                       			
+                                       			
+                                       """);
+        var result = await ParserUtils.GetSpawnGroupCollectionFromBlock(input);
+
+        result.Should().BeEquivalentTo(new SpawnGroupCollection
+        {
+            Name = "a1_01",
+            Id = 101,
+            Members =
+            {
+                new SpawnGroupCollectionMember { Id = 101, Amount = 1 },
+                new SpawnGroupCollectionMember { Id = 171, Amount = 1 }
+            }
+        });
+    }
+
+    [Fact]
+    public async Task GroupCollection_NoContent()
+    {
+        var input = new StringReader("""
+                                       			
+                                       """);
+        var result = await ParserUtils.GetSpawnGroupCollectionFromBlock(input);
+
+        result.Should().BeNull();
+    }
+}

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="Serilog.Enrichers.ExceptionData" Version="1.0.0" />
     <PackageReference Include="Serilog.Enrichers.Process" Version="2.0.2-dev-00741" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0-dev-00839" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0-dev-00887" />
     <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.1-dev-00771" />

--- a/Core/Core/Networking/Connection.cs
+++ b/Core/Core/Networking/Connection.cs
@@ -50,7 +50,7 @@ namespace QuantumCore.Core.Networking
         {
             _client = client;
             _cts = new CancellationTokenSource();
-            SendPacketsWhenPossible().GetAwaiter(); // ignore warning
+            Task.Factory.StartNew(SendPacketsWhenPossible, TaskCreationOptions.LongRunning);
         }
 
         protected abstract void OnHandshakeFinished();

--- a/Core/Core/Networking/Connection.cs
+++ b/Core/Core/Networking/Connection.cs
@@ -128,11 +128,10 @@ namespace QuantumCore.Core.Networking
 
                         try
                         {
-                            await _pluginExecutor.ExecutePlugins<IPacketOperationListener>(_logger, x => x.OnPrePacketSentAsync(obj, CancellationToken.None));
-                            _logger.LogDebug("Sending bytes: {Bytes:X}", bytesToSend.ToArray());
-                            await _stream.WriteAsync(bytesToSend);
-                            await _stream.FlushAsync();
-                            await _pluginExecutor.ExecutePlugins<IPacketOperationListener>(_logger, x => x.OnPostPacketReceivedAsync(obj, bytes, CancellationToken.None));
+                            await _pluginExecutor.ExecutePlugins<IPacketOperationListener>(_logger, x => x.OnPrePacketSentAsync(obj, CancellationToken.None)).ConfigureAwait(false);
+                            await _stream.WriteAsync(bytesToSend).ConfigureAwait(false);
+                            await _stream.FlushAsync().ConfigureAwait(false);
+                            await _pluginExecutor.ExecutePlugins<IPacketOperationListener>(_logger, x => x.OnPostPacketReceivedAsync(obj, bytes, CancellationToken.None)).ConfigureAwait(false);
                         }
                         catch (Exception e)
                         {
@@ -144,7 +143,7 @@ namespace QuantumCore.Core.Networking
                     }
                     else
                     {
-                        await Task.Delay(1); // wait at least 1ms
+                        await Task.Delay(1).ConfigureAwait(false); // wait at least 1ms
                     }
                 }
                 catch (SocketException)

--- a/Core/Core/Networking/Connection.cs
+++ b/Core/Core/Networking/Connection.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Buffers;
+using System.Collections.Concurrent;
 using System.IO;
 using System.Net.Sockets;
 using System.Text.Json;
@@ -23,12 +24,14 @@ namespace QuantumCore.Core.Networking
         private readonly ILogger _logger;
         private readonly PluginExecutor _pluginExecutor;
         private TcpClient _client;
+        private readonly ConcurrentQueue<object> _packetsToSend = new();
 
         private readonly IPacketReader _packetReader;
 
         private Stream _stream;
 
         private long _lastHandshakeTime;
+        private CancellationTokenSource _cts;
 
         public Guid Id { get; }
         public uint Handshake { get; private set; }
@@ -46,6 +49,8 @@ namespace QuantumCore.Core.Networking
         public void Init(TcpClient client)
         {
             _client = client;
+            _cts = new CancellationTokenSource();
+            SendPacketsWhenPossible().GetAwaiter(); // ignore warning
         }
 
         protected abstract void OnHandshakeFinished();
@@ -91,40 +96,63 @@ namespace QuantumCore.Core.Networking
 
         public void Close()
         {
+            _cts.Cancel();
             _client.Close();
             OnClose();
         }
 
-        public async Task Send<T>(T packet) 
-            where T : IPacketSerializable
+        public void Send<T>(T packet) where T : IPacketSerializable
+        {
+            _packetsToSend.Enqueue(packet);
+        }
+
+        public async Task SendPacketsWhenPossible()
         {
             if (!_client.Connected)
             {
                 _logger.LogWarning("Tried to send data to a closed connection");
                 return;
             }
-
-            var size = packet.GetSize();
-            var bytes = ArrayPool<byte>.Shared.Rent(size);
-            Array.Clear(bytes, 0, size);
-            packet.Serialize(bytes);
-            var bytesToSend = bytes.AsMemory(0, size);
-
-            try
+            while (!_cts.IsCancellationRequested)
             {
-                await _pluginExecutor.ExecutePlugins<IPacketOperationListener>(_logger, x => x.OnPrePacketSentAsync(packet, CancellationToken.None));
-                _logger.LogDebug("Sending bytes: {Bytes:X}", bytesToSend.ToArray());
-                await _stream.WriteAsync(bytesToSend);
-                await _stream.FlushAsync();
-                await _pluginExecutor.ExecutePlugins<IPacketOperationListener>(_logger, x => x.OnPostPacketReceivedAsync(packet, bytes, CancellationToken.None));
+                try
+                {
+                    if (_packetsToSend.TryDequeue(out var obj))
+                    {
+                        var packet = (IPacketSerializable) obj;
+                        var size = packet.GetSize();
+                        var bytes = ArrayPool<byte>.Shared.Rent(size);
+                        Array.Clear(bytes, 0, size);
+                        packet.Serialize(bytes);
+                        var bytesToSend = bytes.AsMemory(0, size);
+
+                        try
+                        {
+                            await _pluginExecutor.ExecutePlugins<IPacketOperationListener>(_logger, x => x.OnPrePacketSentAsync(obj, CancellationToken.None));
+                            _logger.LogDebug("Sending bytes: {Bytes:X}", bytesToSend.ToArray());
+                            await _stream.WriteAsync(bytesToSend);
+                            await _stream.FlushAsync();
+                            await _pluginExecutor.ExecutePlugins<IPacketOperationListener>(_logger, x => x.OnPostPacketReceivedAsync(obj, bytes, CancellationToken.None));
+                        }
+                        catch (Exception e)
+                        {
+                            _logger.LogError(e, "Failed to send packet");
+                        }
+
+                        ArrayPool<byte>.Shared.Return(bytes);
+                        _logger.LogInformation("OUT: {Type} => {Packet}", packet.GetType(), JsonSerializer.Serialize(obj));
+                    }
+                    else
+                    {
+                        await Task.Delay(1); // wait at least 1ms
+                    }
+                }
+                catch (SocketException)
+                {
+                    // connection closed. Ignore
+                    break;
+                }
             }
-            catch (Exception e)
-            {
-                _logger.LogError(e, "Failed to send packet");
-            }
-            
-            ArrayPool<byte>.Shared.Return(bytes);
-            _logger.LogInformation("OUT: {Type} => {Packet}", packet.GetType(), JsonSerializer.Serialize(packet));
         }
 
         public async Task StartHandshake()
@@ -138,8 +166,8 @@ namespace QuantumCore.Core.Networking
             // Generate random handshake and start the handshaking
             Handshake = CoreRandom.GenerateUInt32();
             Handshaking = true;
-            await this.SetPhaseAsync(EPhases.Handshake);
-            await SendHandshake();
+            this.SetPhaseAsync(EPhases.Handshake);
+            SendHandshake();
         }
 
         public async Task<bool> HandleHandshake(GCHandshakeData handshake)
@@ -172,7 +200,7 @@ namespace QuantumCore.Core.Networking
             }
             else
             {
-                // calculate new delta 
+                // calculate new delta
                 var delta = (time - handshake.Time) / 2;
                 if (delta < 0)
                 {
@@ -180,23 +208,23 @@ namespace QuantumCore.Core.Networking
                     _logger.LogDebug($"Delta is too low, retry with last send time");
                 }
 
-                await SendHandshake((uint) time, (uint) delta);
+                SendHandshake((uint) time, (uint) delta);
             }
 
             return true;
         }
 
-        private async Task SendHandshake()
+        private void SendHandshake()
         {
             var time = GetServerTime();
             _lastHandshakeTime = time;
-            await Send(new GCHandshake(Handshake, (uint)time, 0));
+            Send(new GCHandshake(Handshake, (uint)time, 0));
         }
 
-        private async Task SendHandshake(uint time, uint delta)
+        private void SendHandshake(uint time, uint delta)
         {
             _lastHandshakeTime = time;
-            await Send(new GCHandshake(Handshake, time, delta));
+            Send(new GCHandshake(Handshake, time, delta));
         }
     }
 }

--- a/Core/Core/Networking/ServerBase.cs
+++ b/Core/Core/Networking/ServerBase.cs
@@ -19,12 +19,12 @@ using QuantumCore.Networking;
 
 namespace QuantumCore.Core.Networking
 {
-    public abstract class ServerBase<T> : BackgroundService, IServerBase 
+    public abstract class ServerBase<T> : BackgroundService, IServerBase
         where T : IConnection
     {
         private readonly ILogger _logger;
         protected IPacketManager PacketManager { get; }
-        private readonly List<Func<IConnection, Task<bool>>> _connectionListeners = new();
+        private readonly List<Func<IConnection, bool>> _connectionListeners = new();
         private readonly ConcurrentDictionary<Guid, IConnection> _connections = new();
         private readonly Dictionary<ushort, IPacketHandler> _listeners = new();
         private readonly Stopwatch _serverTimer = new();
@@ -49,10 +49,10 @@ namespace QuantumCore.Core.Networking
             _serverMode = mode;
             PacketManager = packetManager;
             Port = hostingOptions.Value.Port;
-            
+
             // Start server timer
             _serverTimer.Start();
-            
+
             var localAddr = IPAddress.Parse(hostingOptions.Value.IpAddress);
             Listener = new TcpListener(localAddr, Port);
 
@@ -64,7 +64,7 @@ namespace QuantumCore.Core.Networking
         public async Task RemoveConnection(IConnection connection)
         {
             _connections.Remove(connection.Id, out _);
-            
+
             await _pluginExecutor.ExecutePlugins<IConnectionLifetimeListener>(_logger, x => x.OnDisconnectedAsync(_stoppingToken.Token));
         }
 
@@ -83,19 +83,19 @@ namespace QuantumCore.Core.Networking
         {
             var listener = (TcpListener) ar.AsyncState;
             var client = listener!.EndAcceptTcpClient(ar);
-            
-            // will dispose once connection finished executing (canceled or disconnect) 
+
+            // will dispose once connection finished executing (canceled or disconnect)
             await using var scope = _serviceProvider.CreateAsyncScope();
 
             // cannot inject tcp client here
             var connection = ActivatorUtilities.CreateInstance<T>(scope.ServiceProvider, client, (IServerBase) this);
             _connections.TryAdd(connection.Id, connection);
-            
+
             await _pluginExecutor.ExecutePlugins<IConnectionLifetimeListener>(_logger, x => x.OnConnectedAsync(_stoppingToken.Token));
 
             // accept new connections on another thread
             Listener.BeginAcceptTcpClient(OnClientAccepted, Listener);
-            
+
             await connection.StartAsync(_stoppingToken.Token);
             await connection.ExecuteTask.ConfigureAwait(false);
         }
@@ -108,7 +108,7 @@ namespace QuantumCore.Core.Networking
             }
         }
 
-        public void RegisterNewConnectionListener(Func<IConnection, Task<bool>> listener)
+        public void RegisterNewConnectionListener(Func<IConnection, bool> listener)
         {
             _connectionListeners.Add(listener);
         }
@@ -120,7 +120,7 @@ namespace QuantumCore.Core.Networking
                 _logger.LogWarning("Could not find a handler for packet {PacketType}", packet.GetType());
                 return;
             }
-            
+
             object context;
             if (_serverMode == "game")
             {
@@ -208,14 +208,14 @@ namespace QuantumCore.Core.Networking
                     _logger.LogWarning("Base interface did not match {BaseInterface} this should not happen", nameof(IPacketHandler));
                     continue;
                 }
-                
+
                 var packetDescription = packetType.GetCustomAttribute<PacketAttribute>();
                 if (packetDescription is null)
                 {
                     _logger.LogWarning("Packet type {Type} is missing a {AttributeTypeName}", packetType.Name, nameof(PacketAttribute));
                     continue;
                 }
-                
+
                 var subPacketDescription = packetType.GetCustomAttribute<SubPacketAttribute>();
                 if (subPacketDescription is not null)
                 {

--- a/Core/Extensions/ConnectionExtensions.cs
+++ b/Core/Extensions/ConnectionExtensions.cs
@@ -7,10 +7,10 @@ namespace QuantumCore.Extensions;
 
 public static class ConnectionExtensions
 {
-    public static async Task SetPhaseAsync(this IConnection connection, EPhases phase)
+    public static void SetPhaseAsync(this IConnection connection, EPhases phase)
     {
         connection.Phase = phase;
-        await connection.Send(new GCPhase
+        connection.Send(new GCPhase
         {
             Phase = connection.Phase
         });

--- a/Core/QuantumCoreHostBuilder.cs
+++ b/Core/QuantumCoreHostBuilder.cs
@@ -25,7 +25,7 @@ public static class QuantumCoreHostBuilder
             // may be null in single file deployment
             Directory.SetCurrentDirectory(Path.GetDirectoryName(assemblyPath)!);
         }
-            
+
         // init plugins if any
         IPluginCatalog pluginCatalog = new EmptyPluginCatalog();
         if (Directory.Exists("plugins"))
@@ -48,7 +48,7 @@ public static class QuantumCoreHostBuilder
             .UseConsoleLifetime(x => x.SuppressStatusMessages = true)
             .ConfigureServices((ctx, services) =>
             {
-                services.AddCoreServices(pluginCatalog);
+                services.AddCoreServices(pluginCatalog, ctx.Configuration);
 
                 var serviceCollectionPluginTypes = pluginCatalog.GetPlugins()
                     .FindAll(x => typeof(IServiceCollectionPlugin).IsAssignableFrom(x.Type))

--- a/CorePluginAPI/Core/Models/PlayerData.cs
+++ b/CorePluginAPI/Core/Models/PlayerData.cs
@@ -26,4 +26,10 @@ public class PlayerData
     public uint HairPart { get; set; }
     public uint GivenStatusPoints { get; set; }
     public uint AvailableStatusPoints { get; set; }
+    public uint MinWeaponDamage { get; set; }
+    public uint MaxWeaponDamage { get; set; }
+    public uint MinAttackDamage { get; set; }
+    public uint MaxAttackDamage { get; set; }
+    public uint MaxHp { get; set; }
+    public uint MaxSp { get; set; }
 }

--- a/CorePluginAPI/Game/World/AI/IBehaviour.cs
+++ b/CorePluginAPI/Game/World/AI/IBehaviour.cs
@@ -9,19 +9,19 @@ namespace QuantumCore.API.Game.World.AI
         /// </summary>
         /// <param name="entity">Entity who's getting controlled by this behaviour</param>
         void Init(IEntity entity);
-        
+
         /// <summary>
         /// Executes behaviour logic
         /// </summary>
-        Task Update(double elapsedTime);
-        
+        void Update(double elapsedTime);
+
         /// <summary>
         /// Called as soon as the entity got damage
         /// </summary>
         /// <param name="attacker">Attacker / source of the damage</param>
         /// <param name="damage">Damage dealt</param>
         void TookDamage(IEntity attacker, uint damage);
-        
+
         /// <summary>
         /// Called as soon as a entity enters the view of the controlled entity
         /// </summary>

--- a/CorePluginAPI/Game/World/IEntity.cs
+++ b/CorePluginAPI/Game/World/IEntity.cs
@@ -50,7 +50,7 @@ namespace QuantumCore.API.Game.World
 
         public void Update(double elapsedTime);
 
-        public ValueTask OnDespawn();
+        public void OnDespawn();
         public void AddNearbyEntity(IEntity entity);
         public void RemoveNearbyEntity(IEntity entity);
         public void ForEachNearbyEntity(Action<IEntity> action);

--- a/CorePluginAPI/Game/World/IEntity.cs
+++ b/CorePluginAPI/Game/World/IEntity.cs
@@ -18,7 +18,7 @@ namespace QuantumCore.API.Game.World
         Npc = 1,
         Player = 6
     }
-    
+
     public interface IEntity
     {
         public uint Vid { get; }
@@ -34,7 +34,7 @@ namespace QuantumCore.API.Game.World
         public byte HealthPercentage { get; }
         public List<IPlayerEntity> TargetedBy { get; }
         public bool Dead { get; }
-        
+
         // QuadTree cache
         public int LastPositionX { get; set; }
         public int LastPositionY { get; set; }
@@ -48,29 +48,30 @@ namespace QuantumCore.API.Game.World
         public int StartPositionY { get; }
         public uint MovementDuration { get; }
 
-        public Task Update(double elapsedTime);
-        
+        public void Update(double elapsedTime);
+
         public ValueTask OnDespawn();
-        public ValueTask AddNearbyEntity(IEntity entity);
-        public ValueTask RemoveNearbyEntity(IEntity entity);
-        public Task ForEachNearbyEntity(Func<IEntity, Task> action);
-        public Task ShowEntity(IConnection connection);
-        public Task HideEntity(IConnection connection);
+        public void AddNearbyEntity(IEntity entity);
+        public void RemoveNearbyEntity(IEntity entity);
+        public void ForEachNearbyEntity(Action<IEntity> action);
+        public void ShowEntity(IConnection connection);
+        public void HideEntity(IConnection connection);
+        IReadOnlyCollection<IEntity> NearbyEntities { get; }
 
         public uint GetPoint(EPoints point);
         public int GetMinDamage();
         public int GetMaxDamage();
         public int GetBonusDamage();
 
-        public Task Goto(int x, int y);
+        public void Goto(int x, int y);
         public void Wait(int x, int y);
 
         public byte GetBattleType();
-        public Task Attack(IEntity victim, byte type);
-        public Task<int> Damage(IEntity attacker, EDamageType damageType, int damage);
+        public void Attack(IEntity victim, byte type);
+        public int Damage(IEntity attacker, EDamageType damageType, int damage);
 
-        public Task Move(int x, int y);
+        public void Move(int x, int y);
         public void Stop();
-        public ValueTask Die();
+        public void Die();
     }
 }

--- a/CorePluginAPI/Game/World/IMap.cs
+++ b/CorePluginAPI/Game/World/IMap.cs
@@ -18,11 +18,11 @@ namespace QuantumCore.API.Game.World
         public IEntity GetEntity(uint vid);
 
         public bool SpawnEntity(IEntity entity);
-        
+
         public Task DespawnEntity(IEntity entity);
 
         public bool IsPositionInside(int x, int y);
 
-        public ValueTask Update(double elapsedTime);
+        public void Update(double elapsedTime);
     }
 }

--- a/CorePluginAPI/Game/World/IMap.cs
+++ b/CorePluginAPI/Game/World/IMap.cs
@@ -13,13 +13,13 @@ namespace QuantumCore.API.Game.World
         public uint Width { get; }
         public uint Height { get; }
 
-        public List<IEntity> GetEntities();
+        public IReadOnlyCollection<IEntity> Entities { get; }
 
         public IEntity GetEntity(uint vid);
 
-        public bool SpawnEntity(IEntity entity);
+        public void SpawnEntity(IEntity entity);
 
-        public Task DespawnEntity(IEntity entity);
+        public void DespawnEntity(IEntity entity);
 
         public bool IsPositionInside(int x, int y);
 

--- a/CorePluginAPI/Game/World/IPlayerEntity.cs
+++ b/CorePluginAPI/Game/World/IPlayerEntity.cs
@@ -20,36 +20,36 @@ namespace QuantumCore.API.Game.World
         Dictionary<string, IQuest> Quests { get; }
         EAntiFlags AntiFlagClass { get; }
         EAntiFlags AntiFlagGender { get; }
-        
+
         Task Load();
         T GetQuestInstance<T>() where T : IQuest;
-        Task Respawn(bool town);
+        void Respawn(bool town);
         uint CalculateAttackDamage(uint baseDamage);
         uint GetHitRate();
-        ValueTask AddPoint(EPoints point, int value);
-        ValueTask SetPoint(EPoints point, uint value);
-        Task DropItem(ItemInstance item, byte count);
-        Task Pickup(IGroundItem groundItem);
-        Task DropGold(uint amount);
+        void AddPoint(EPoints point, int value);
+        void SetPoint(EPoints point, uint value);
+        void DropItem(ItemInstance item, byte count);
+        void Pickup(IGroundItem groundItem);
+        void DropGold(uint amount);
         ItemInstance GetItem(byte window, ushort position);
         bool IsSpaceAvailable(ItemInstance item, byte window, ushort position);
         bool IsEquippable(ItemInstance item);
-        Task<bool> DestroyItem(ItemInstance item);
-        Task RemoveItem(ItemInstance item);
-        Task SetItem(ItemInstance item, byte window, ushort position);
-        Task SendBasicData();
-        Task SendPoints();
-        Task SendInventory();
-        Task SendItem(ItemInstance item);
-        Task SendRemoveItem(byte window, ushort position);
-        Task SendCharacter(IConnection connection);
-        Task SendCharacterAdditional(IConnection connection);
-        Task SendCharacterUpdate();
-        Task SendChatMessage(string message);
-        Task SendChatCommand(string message);
-        Task SendChatInfo(string message);
-        Task SendTarget();
-        Task Show(IConnection connection);
+        bool DestroyItem(ItemInstance item);
+        void RemoveItem(ItemInstance item);
+        void SetItem(ItemInstance item, byte window, ushort position);
+        void SendBasicData();
+        void SendPoints();
+        void SendInventory();
+        void SendItem(ItemInstance item);
+        void SendRemoveItem(byte window, ushort position);
+        void SendCharacter(IConnection connection);
+        void SendCharacterAdditional(IConnection connection);
+        void SendCharacterUpdate();
+        void SendChatMessage(string message);
+        void SendChatCommand(string message);
+        void SendChatInfo(string message);
+        void SendTarget();
+        void Show(IConnection connection);
         void Disconnect();
         string ToString();
     }

--- a/CorePluginAPI/Game/World/IWorld.cs
+++ b/CorePluginAPI/Game/World/IWorld.cs
@@ -8,7 +8,7 @@ namespace QuantumCore.API.Game.World
     {
         static IWorld Instance { get; set; }
         Task Load();
-        void Update(double elapsedTime);
+        Task Update(double elapsedTime);
         IMap GetMapAt(uint x, uint y);
         IMap GetMapByName(string name);
         List<IMap> FindMapsByName(string needle);

--- a/CorePluginAPI/Game/World/IWorld.cs
+++ b/CorePluginAPI/Game/World/IWorld.cs
@@ -13,7 +13,10 @@ namespace QuantumCore.API.Game.World
         IMap GetMapByName(string name);
         List<IMap> FindMapsByName(string needle);
         CoreHost GetMapHost(int x, int y);
-        SpawnGroup GetGroup(int id);
+        #nullable enable
+        SpawnGroup? GetGroup(uint id);
+        SpawnGroupCollection? GetGroupCollection(uint id);
+        #nullable restore
         ValueTask<bool> SpawnEntity(IEntity e);
         Task DespawnEntity(IEntity entity);
         uint GenerateVid();

--- a/CorePluginAPI/Game/World/IWorld.cs
+++ b/CorePluginAPI/Game/World/IWorld.cs
@@ -8,7 +8,7 @@ namespace QuantumCore.API.Game.World
     {
         static IWorld Instance { get; set; }
         Task Load();
-        Task Update(double elapsedTime);
+        void Update(double elapsedTime);
         IMap GetMapAt(uint x, uint y);
         IMap GetMapByName(string name);
         List<IMap> FindMapsByName(string needle);
@@ -17,8 +17,8 @@ namespace QuantumCore.API.Game.World
         SpawnGroup? GetGroup(uint id);
         SpawnGroupCollection? GetGroupCollection(uint id);
         #nullable restore
-        ValueTask<bool> SpawnEntity(IEntity e);
-        Task DespawnEntity(IEntity entity);
+        bool SpawnEntity(IEntity e);
+        void DespawnEntity(IEntity entity);
         uint GenerateVid();
         void RemovePlayer(IPlayerEntity e);
         IPlayerEntity GetPlayer(string playerName);

--- a/CorePluginAPI/Game/World/IWorld.cs
+++ b/CorePluginAPI/Game/World/IWorld.cs
@@ -17,7 +17,7 @@ namespace QuantumCore.API.Game.World
         SpawnGroup? GetGroup(uint id);
         SpawnGroupCollection? GetGroupCollection(uint id);
         #nullable restore
-        bool SpawnEntity(IEntity e);
+        void SpawnEntity(IEntity e);
         void DespawnEntity(IEntity entity);
         uint GenerateVid();
         void RemovePlayer(IPlayerEntity e);

--- a/CorePluginAPI/Game/World/SpawnGroup.cs
+++ b/CorePluginAPI/Game/World/SpawnGroup.cs
@@ -6,11 +6,24 @@ namespace QuantumCore.API.Game.World
     {
         public uint Id { get; set; }
     }
-    
+    public class SpawnGroupCollectionMember
+    {
+        public uint Id { get; set; }
+        public byte Amount { get; set; }
+    }
+
     public class SpawnGroup
     {
-        public int Id { get; set; }
+        public uint Id { get; set; }
         public string Name { get; set; }
+        public uint Leader { get; set; }
         public List<SpawnMember> Members { get; } = new List<SpawnMember>();
+    }
+
+    public class SpawnGroupCollection
+    {
+        public uint Id { get; set; }
+        public string Name { get; set; }
+        public List<SpawnGroupCollectionMember> Members { get; } = new List<SpawnGroupCollectionMember>();
     }
 }

--- a/CorePluginAPI/IConnection.cs
+++ b/CorePluginAPI/IConnection.cs
@@ -12,7 +12,7 @@ namespace QuantumCore.API
         EPhases Phase { get; set; }
         Task ExecuteTask { get; }
         void Close();
-        Task Send<T>(T packet) where T : IPacketSerializable;
+        void Send<T>(T packet) where T : IPacketSerializable;
         Task StartAsync(CancellationToken token = default);
     }
 }

--- a/CorePluginAPI/IEquipment.cs
+++ b/CorePluginAPI/IEquipment.cs
@@ -24,5 +24,5 @@ public interface IEquipment
     bool RemoveItem(ItemInstance item);
     Task Send(IPlayerEntity player);
     bool IsSuitable(IItemManager itemManager, ItemInstance item, ushort position);
-    long GetWearSlot(IItemManager itemManager, ItemInstance item);
+    long GetWearPosition(IItemManager itemManager, ItemInstance item);
 }

--- a/CorePluginAPI/IGroundItem.cs
+++ b/CorePluginAPI/IGroundItem.cs
@@ -9,6 +9,4 @@ public interface IGroundItem : IEntity
 {
     ItemInstance Item { get; }
     uint Amount { get; }
-    ValueTask AddPoint(EPoints point, int value);
-    ValueTask SetPoint(EPoints point, uint value);
 }

--- a/CorePluginAPI/IInventory.cs
+++ b/CorePluginAPI/IInventory.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using QuantumCore.API.Core.Models;
 
 namespace QuantumCore.API;
@@ -12,6 +13,7 @@ public interface IInventory
     ReadOnlyCollection<ItemInstance> Items { get; }
     IEquipment EquipmentWindow { get; }
     long Size { get; }
+    event EventHandler<SlotChangedEventArgs> OnSlotChanged;
     Task Load();
     Task<bool> PlaceItem(ItemInstance instance);
     Task<bool> PlaceItem(ItemInstance item, ushort position);

--- a/CorePluginAPI/IInventory.cs
+++ b/CorePluginAPI/IInventory.cs
@@ -21,4 +21,5 @@ public interface IInventory
     ItemInstance GetItem(ushort position);
     bool IsSpaceAvailable(ItemInstance item, ushort position);
     void MoveItem(ItemInstance item, ushort fromPosition, ushort position);
+    void SetEquipment(ItemInstance item, ushort position);
 }

--- a/CorePluginAPI/SlotChangedEventArgs.cs
+++ b/CorePluginAPI/SlotChangedEventArgs.cs
@@ -1,0 +1,6 @@
+﻿#nullable enable
+using QuantumCore.API.Core.Models;
+
+namespace QuantumCore.API;
+
+public record struct SlotChangedEventArgs(ItemInstance? ItemInstance, EquipmentSlots Slot);

--- a/Executables/Auth/AuthServer.cs
+++ b/Executables/Auth/AuthServer.cs
@@ -15,8 +15,8 @@ namespace QuantumCore.Auth
         private readonly ILogger<AuthServer> _logger;
         private readonly ICacheManager _cacheManager;
 
-        public AuthServer(IOptions<HostingOptions> hostingOptions, IPacketManager packetManager, ILogger<AuthServer> logger, 
-            PluginExecutor pluginExecutor, IServiceProvider serviceProvider, 
+        public AuthServer(IOptions<HostingOptions> hostingOptions, IPacketManager packetManager, ILogger<AuthServer> logger,
+            PluginExecutor pluginExecutor, IServiceProvider serviceProvider,
             IEnumerable<IPacketHandler> packetHandlers, ICacheManager cacheManager)
             : base(packetManager, logger, pluginExecutor, serviceProvider, packetHandlers, "auth", hostingOptions)
         {
@@ -29,7 +29,7 @@ namespace QuantumCore.Auth
             // Register auth server features
             RegisterNewConnectionListener(NewConnection);
             RegisterListeners();
-            
+
             var pong = await _cacheManager.Ping();
             if (!pong)
             {
@@ -37,9 +37,9 @@ namespace QuantumCore.Auth
             }
         }
 
-        private async Task<bool> NewConnection(IConnection connection)
+        private bool NewConnection(IConnection connection)
         {
-            await connection.SetPhaseAsync(EPhases.Auth);
+            connection.SetPhaseAsync(EPhases.Auth);
             return true;
         }
     }

--- a/Executables/Auth/PacketHandlers/LoginRequestHandler.cs
+++ b/Executables/Auth/PacketHandlers/LoginRequestHandler.cs
@@ -34,16 +34,16 @@ public class LoginRequestHandler : IAuthPacketHandler<LoginRequest>
         {
             // Hash the password to prevent timing attacks
             BCrypt.Net.BCrypt.HashPassword(ctx.Packet.Password);
-            
+
             _logger.LogDebug("Account {Username} not found", ctx.Packet.Username);
-            await ctx.Connection.Send(new LoginFailed
+            ctx.Connection.Send(new LoginFailed
             {
                 Status = "WRONGPWD"
             });
 
             return;
         }
-        
+
         var status = "";
 
         // Verify the password against the stored one
@@ -73,17 +73,17 @@ public class LoginRequestHandler : IAuthPacketHandler<LoginRequest>
         // If the status is not empty send a failed login response to the client
         if (status != "")
         {
-            await ctx.Connection.Send(new LoginFailed
+            ctx.Connection.Send(new LoginFailed
             {
                 Status = status
             });
 
             return;
         }
-        
+
         // Generate authentication token
         var authToken = CoreRandom.GenerateUInt32();
-        
+
         // Store auth token
         await _cacheManager.Set("token:" + authToken, new Token
         {
@@ -92,9 +92,9 @@ public class LoginRequestHandler : IAuthPacketHandler<LoginRequest>
         });
         // Set expiration on token
         await _cacheManager.Expire("token:" + authToken, 30);
-        
+
         // Send the auth token to the client and let it connect to our game server
-        await ctx.Connection.Send(new LoginSuccess
+        ctx.Connection.Send(new LoginSuccess
         {
             Key = authToken,
             Result = 1

--- a/Executables/Game/ChatManager.cs
+++ b/Executables/Game/ChatManager.cs
@@ -25,7 +25,7 @@ public class ChatManager : IChatManager
     {
         _cacheManager = cacheManager;
     }
-    
+
     public void Init()
     {
         _id = Guid.NewGuid();
@@ -44,7 +44,7 @@ public class ChatManager : IChatManager
             // It's our own message, we don't have to handle it here
             return;
         }
-        
+
         var chat = new ChatOutcoming
         {
             MessageType = message.Type,
@@ -52,7 +52,7 @@ public class ChatManager : IChatManager
             Empire = 1, // todo
             Message = message.Message
         };
-        
+
         // Send message to all connections in the game phase
         await GameServer.Instance.ForAllConnections(async connection =>
         {
@@ -60,11 +60,11 @@ public class ChatManager : IChatManager
             {
                 return;
             }
-            
-            await connection.Send(chat);
+
+            connection.Send(chat);
         });
     }
-    
+
     public async ValueTask Talk(IEntity entity, string message)
     {
         var packet = new ChatOutcoming
@@ -77,16 +77,16 @@ public class ChatManager : IChatManager
 
         if (entity is IPlayerEntity player)
         {
-            await player.Connection.Send(packet);
+            player.Connection.Send(packet);
         }
-        
-        await entity.ForEachNearbyEntity(async nearby =>
+
+        foreach (var nearby in entity.NearbyEntities)
         {
-            if (nearby is PlayerEntity player)
+            if (nearby is PlayerEntity p)
             {
-                await player.Connection.Send(packet);
+                p.Connection.Send(packet);
             }
-        });
+        }
     }
 
     public async Task Shout(string message)
@@ -98,7 +98,7 @@ public class ChatManager : IChatManager
             Empire = 1, // todo
             Message = message
         };
-        
+
         // Send message to all connections in the game phase
         await GameServer.Instance.ForAllConnections(async connection =>
         {
@@ -106,11 +106,11 @@ public class ChatManager : IChatManager
             {
                 return;
             }
-            
-            await connection.Send(chat);
+
+            connection.Send(chat);
         });
-        
-        // Broadcast message to all cores 
+
+        // Broadcast message to all cores
         await _cacheManager.Publish("chat",
             new ChatMessage {Type = ChatMessageTypes.Shout, Message = message, OwnerCore = _id});
     }

--- a/Executables/Game/Commands/ClearInventoryCommand.cs
+++ b/Executables/Game/Commands/ClearInventoryCommand.cs
@@ -14,7 +14,7 @@ namespace QuantumCore.Game.Commands
         {
             _cacheManager = cacheManager;
         }
-        
+
         public async Task ExecuteAsync(CommandContext ctx)
         {
             var items = ctx.Player.Inventory.Items
@@ -31,12 +31,12 @@ namespace QuantumCore.Game.Commands
                 .ToArray();
             foreach (var item in items)
             {
-                await ctx.Player.RemoveItem(item);
-                await ctx.Player.SendRemoveItem(item.Window, (ushort)item.Position);
+                ctx.Player.RemoveItem(item);
+                ctx.Player.SendRemoveItem(item.Window, (ushort)item.Position);
                 await item.Destroy(_cacheManager);
             }
 
-            await ctx.Player.SendInventory();
+            ctx.Player.SendInventory();
         }
     }
 

--- a/Executables/Game/Commands/CommandCache.cs
+++ b/Executables/Game/Commands/CommandCache.cs
@@ -4,7 +4,7 @@ using QuantumCore.API.Game.World;
 
 namespace QuantumCore.Game.Commands
 {
-    
+
     public class CommandFunction
     {
         public string Description { get; set; }
@@ -51,7 +51,7 @@ namespace QuantumCore.Game.Commands
             {
                 return true;
             }
-            
+
             if (input == typeof(int))
             {
                 if (expected == typeof(uint) || expected == typeof(byte) || expected == typeof(ushort))
@@ -63,15 +63,15 @@ namespace QuantumCore.Game.Commands
             return false;
         }
 
-        public async Task Run(object[] args)
+        public Task Run(object[] args)
         {
             MethodInfo method = null;
-            
+
             foreach (var function in Functions)
             {
                 var callArguments = new object[args.Length];
                 Array.Copy(args, callArguments, args.Length);
-                
+
                 var param = function.Method.GetParameters();
 
                 if (param.Length < args.Length)
@@ -79,7 +79,7 @@ namespace QuantumCore.Game.Commands
                     method = null;
                     continue;
                 }
-                
+
                 method = function.Method;
 
                 for (var i = 1; i < param.Length; i++) // Parameter 0 is always an IPlayer, no reason to check it
@@ -110,8 +110,8 @@ namespace QuantumCore.Game.Commands
                                 var player = _world.GetPlayer((string) callArguments[i]);
                                 if (player == null)
                                 {
-                                    await ((IPlayerEntity) callArguments[0]).SendChatInfo($"Cannot find player {(string)callArguments[i]}");
-                                    return;
+                                    ((IPlayerEntity) callArguments[0]).SendChatInfo($"Cannot find player {(string)callArguments[i]}");
+                                    return Task.CompletedTask;
                                 }
                                 callArguments[i] = player;
                             }
@@ -132,11 +132,12 @@ namespace QuantumCore.Game.Commands
                 if (method != null)
                 {
                     method.Invoke(null, callArguments);
-                    return;
+                    return Task.CompletedTask;
                 }
             }
 
-            await ((IPlayerEntity)args[0]).SendChatInfo("Invalid command parameters");
+            ((IPlayerEntity)args[0]).SendChatInfo("Invalid command parameters");
+            return Task.CompletedTask;
         }
     }
 }

--- a/Executables/Game/Commands/CommandManager.cs
+++ b/Executables/Game/Commands/CommandManager.cs
@@ -41,12 +41,12 @@ namespace QuantumCore.Game.Commands
             _world = world;
             _serviceProvider = serviceProvider;
         }
-        
+
         public void Register(string ns, Assembly assembly = null)
         {
             _logger.LogDebug("Registring commands from namespace {Namespace}", ns);
             if (assembly == null) assembly = Assembly.GetAssembly(typeof(CommandManager))!;
-            
+
             var types = assembly.GetTypes().Where(t => string.Equals(t.Namespace, ns, StringComparison.Ordinal))
                 .Where(t => (t.GetInterfaces().Any(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(ICommandHandler<>))
                              || typeof(ICommandHandler).IsAssignableFrom(t)) && t.IsClass && !t.IsAbstract)
@@ -189,8 +189,8 @@ namespace QuantumCore.Game.Commands
                 }
 
                 var msg = sb.ToString();
-                
-                await connection.Player.SendChatMessage(msg);
+
+                connection.Player.SendChatMessage(msg);
             }
             else
             {
@@ -198,7 +198,7 @@ namespace QuantumCore.Game.Commands
                 {
                     if (!CanUseCommand(connection.Player, command))
                     {
-                        await connection.Send(new ChatOutcoming()
+                        connection.Send(new ChatOutcoming()
                         {
                             MessageType = ChatMessageTypes.Info,
                             Vid = 0,
@@ -214,7 +214,7 @@ namespace QuantumCore.Game.Commands
                             .GetMethods()
                             .Single(x => x.Name == nameof(Parser.ParseArguments) && x.GetParameters().Length == 1)
                             .MakeGenericMethod(commandCache.OptionsType);
-                        
+
                         // basically makes a ICommandHandler<TCommandOptions> for the given command
                         // creates a context with the given CommandContext<TCommandContext>
                         // invokes the command
@@ -233,10 +233,10 @@ namespace QuantumCore.Game.Commands
                             return param1.IsGenericType &&
                                    param1.GetGenericTypeDefinition() == typeof(ParserResult<>) &&
                                    param1.GenericTypeArguments[0].IsGenericParameter &&
-                                   
+
                                    param2.IsGenericType &&
                                    param2.GetGenericTypeDefinition() == typeof(Func<,>) &&
-                                   
+
                                    param3.IsGenericType &&
                                    param3.GetGenericTypeDefinition() == typeof(Func<,>) &&
                                    param3.GenericTypeArguments[0] == typeof(IEnumerable<Error>);
@@ -266,7 +266,7 @@ namespace QuantumCore.Game.Commands
                         catch (Exception e)
                         {
                             _logger.LogError(e, "Failed to execute command {Type}!", commandCache.Type.Name);
-                            await connection.Send(new ChatOutcoming()
+                            connection.Send(new ChatOutcoming()
                             {
                                 MessageType = ChatMessageTypes.Info,
                                 Vid = 0,
@@ -283,7 +283,7 @@ namespace QuantumCore.Game.Commands
                 }
                 else
                 {
-                    await connection.Send(new ChatOutcoming()
+                    connection.Send(new ChatOutcoming()
                     {
                         MessageType = ChatMessageTypes.Info,
                         Vid = 0,

--- a/Executables/Game/Commands/CommandTeleportHere.cs
+++ b/Executables/Game/Commands/CommandTeleportHere.cs
@@ -13,19 +13,19 @@ public class CommandTeleportHere : ICommandHandler<TeleportHereOptions>
     {
         _world = world;
     }
-    
+
     public async Task ExecuteAsync(CommandContext<TeleportHereOptions> ctx)
     {
         var target = _world.GetPlayer(ctx.Arguments.Target);
 
         if (target is null)
         {
-            await ctx.Player.SendChatInfo("Target not found");
+            ctx.Player.SendChatInfo("Target not found");
         }
         else
         {
-            await ctx.Player.SendChatInfo($"Teleporting {target.Name} to your position");
-            await target.Move(ctx.Player.PositionX, ctx.Player.PositionY);
+            ctx.Player.SendChatInfo($"Teleporting {target.Name} to your position");
+            target.Move(ctx.Player.PositionX, ctx.Player.PositionY);
         }
     }
 }

--- a/Executables/Game/Commands/CommandTeleportTo.cs
+++ b/Executables/Game/Commands/CommandTeleportTo.cs
@@ -20,12 +20,12 @@ namespace QuantumCore.Game.Commands
 
             if (dest is null)
             {
-                await ctx.Player.SendChatInfo("Destination not found");
+                ctx.Player.SendChatInfo("Destination not found");
             }
             else
             {
-                await ctx.Player.SendChatInfo($"Teleporting to player {dest.Name}");
-                await ctx.Player.Move(dest.PositionX, dest.PositionY);
+                ctx.Player.SendChatInfo($"Teleporting to player {dest.Name}");
+                ctx.Player.Move(dest.PositionX, dest.PositionY);
             }
         }
     }

--- a/Executables/Game/Commands/DebugCommand.cs
+++ b/Executables/Game/Commands/DebugCommand.cs
@@ -12,8 +12,8 @@ namespace QuantumCore.Game.Commands
             var maxWeapon = context.Player.GetPoint(EPoints.MaxWeaponDamage);
             var minAttack = context.Player.GetPoint(EPoints.MinAttackDamage);
             var maxAttack = context.Player.GetPoint(EPoints.MaxAttackDamage);
-            await context.Player.SendChatMessage($"Weapon Damage: {minWeapon}-{maxWeapon}");
-            await context.Player.SendChatMessage($"Attack Damage: {minAttack}-{maxAttack}");
+            context.Player.SendChatMessage($"Weapon Damage: {minWeapon}-{maxWeapon}");
+            context.Player.SendChatMessage($"Attack Damage: {minAttack}-{maxAttack}");
         }
     }
 }

--- a/Executables/Game/Commands/ExperienceCommand.cs
+++ b/Executables/Game/Commands/ExperienceCommand.cs
@@ -26,12 +26,12 @@ public class ExperienceCommand : ICommandHandler<ExperienceOtherOptions>
 
         if (target is null)
         {
-            await context.Player.SendChatMessage("Target not found!");
+            context.Player.SendChatMessage("Target not found!");
         }
         else
         {
-            await target.AddPoint(EPoints.Experience, context.Arguments.Value);
-            await target.SendPoints();   
+            target.AddPoint(EPoints.Experience, context.Arguments.Value);
+            target.SendPoints();
         }
     }
 }
@@ -41,7 +41,7 @@ public class ExperienceOtherOptions
     [Value(0)]
     public int Value { get; set; }
 
-    [Value(1)] 
-    [CanBeNull] 
+    [Value(1)]
+    [CanBeNull]
     public string Target { get; set; }
 }

--- a/Executables/Game/Commands/GiveItemCommand.cs
+++ b/Executables/Game/Commands/GiveItemCommand.cs
@@ -30,14 +30,14 @@ namespace QuantumCore.Game.Commands
 
             if (target is null)
             {
-                await context.Player.SendChatMessage("Target not found");
+                context.Player.SendChatMessage("Target not found");
             }
             else
             {
                 var item = _itemManager.GetItem(context.Arguments.ItemId);
                 if (item == null)
                 {
-                    await context.Player.SendChatInfo("Item not found");
+                    context.Player.SendChatInfo("Item not found");
                     return;
                 }
 
@@ -46,14 +46,14 @@ namespace QuantumCore.Game.Commands
                 if (!await target.Inventory.PlaceItem(instance))
                 {
                     // No space left in inventory, drop item with player name
-                    await context.Player.SendChatInfo("No place in inventory");
+                    context.Player.SendChatInfo("No place in inventory");
                     return;
                 }
                 // Store item in cache
                 await instance.Persist(_cacheManager);
 
                 // Send item to client
-                await target.SendItem(instance);
+                target.SendItem(instance);
             }
         }
     }

--- a/Executables/Game/Commands/GoldCommand.cs
+++ b/Executables/Game/Commands/GoldCommand.cs
@@ -25,12 +25,12 @@ public class GoldCommand : ICommandHandler<GoldCommandOptions>
 
         if (target is null)
         {
-            await context.Player.SendChatMessage("Target not found");
+            context.Player.SendChatMessage("Target not found");
             return;
         }
-        
-        await target.AddPoint(EPoints.Gold, context.Arguments.Value);
-        await target.SendPoints();
+
+        target.AddPoint(EPoints.Gold, context.Arguments.Value);
+        target.SendPoints();
     }
 }
 
@@ -38,7 +38,7 @@ public class GoldCommandOptions
 {
     [Value(0)]
     public int Value { get; set; }
-    
+
     [Value(1)]
     public string Target { get; set; }
 }

--- a/Executables/Game/Commands/GotoCommand.cs
+++ b/Executables/Game/Commands/GotoCommand.cs
@@ -23,10 +23,10 @@ namespace QuantumCore.Game.Commands
                 var maps = _world.FindMapsByName(context.Arguments.Map);
                 if (maps.Count > 1)
                 {
-                    await context.Player.SendChatInfo("Map name is ambiguous:");
+                    context.Player.SendChatInfo("Map name is ambiguous:");
                     foreach (var map in maps)
                     {
-                        await context.Player.SendChatInfo($"- {map.Name}");
+                        context.Player.SendChatInfo($"- {map.Name}");
                     }
 
                     return;
@@ -34,26 +34,26 @@ namespace QuantumCore.Game.Commands
 
                 if (maps.Count == 0)
                 {
-                    await context.Player.SendChatInfo("Unknown map");
+                    context.Player.SendChatInfo("Unknown map");
                     return;
                 }
-            
+
                 // todo read goto position from map instead of using center
 
                 var targetMap = maps[0];
                 var x = (int)(targetMap.PositionX + targetMap.Width * Map.MapUnit / 2);
                 var y = (int)(targetMap.PositionY + targetMap.Height * Map.MapUnit / 2);
-                await context.Player.Move(x, y);
+                context.Player.Move(x, y);
             }
             else
             {
                 if (context.Arguments.X < 0 || context.Arguments.Y < 0)
-                    await context.Player.SendChatInfo("The X and Y position must be positive");
+                    context.Player.SendChatInfo("The X and Y position must be positive");
                 else
                 {
                     var x = (int) context.Player.Map.PositionX + (context.Arguments.X*100);
                     var y = (int) context.Player.Map.PositionY + (context.Arguments.Y*100);
-                    await context.Player.Move(x, y);
+                    context.Player.Move(x, y);
                 }
             }
         }
@@ -61,7 +61,7 @@ namespace QuantumCore.Game.Commands
 
     public class GotoCommandOptions
     {
-        [Option('m', "map")] 
+        [Option('m', "map")]
         [CanBeNull] public string Map { get; set; }
 
         [Value(0)]

--- a/Executables/Game/Commands/HpCommand.cs
+++ b/Executables/Game/Commands/HpCommand.cs
@@ -26,12 +26,12 @@ public class HpCommand : ICommandHandler<HpOtherOptions>
 
         if (target is null)
         {
-            await context.Player.SendChatMessage("Target not found!");
+            context.Player.SendChatMessage("Target not found!");
         }
         else
         {
-            await target.AddPoint(EPoints.Hp, context.Arguments.Value);
-            await target.SendPoints();   
+            target.AddPoint(EPoints.Hp, context.Arguments.Value);
+            target.SendPoints();
         }
     }
 }
@@ -41,7 +41,7 @@ public class HpOtherOptions
     [Value(0)]
     public int Value { get; set; }
 
-    [Value(1)] 
-    [CanBeNull] 
+    [Value(1)]
+    [CanBeNull]
     public string Target { get; set; }
 }

--- a/Executables/Game/Commands/LevelCommand.cs
+++ b/Executables/Game/Commands/LevelCommand.cs
@@ -23,12 +23,12 @@ public class LevelCommand : ICommandHandler<LevelCommandOptions>
 
         if (target is null)
         {
-            await context.Player.SendChatMessage("Target not found");
+            context.Player.SendChatMessage("Target not found");
         }
         else
         {
-            await target.SetPoint(EPoints.Level, context.Arguments.Level);
-            await target.SendPoints();
+            target.SetPoint(EPoints.Level, context.Arguments.Level);
+            target.SendPoints();
         }
     }
 }

--- a/Executables/Game/Commands/LogoutCommand.cs
+++ b/Executables/Game/Commands/LogoutCommand.cs
@@ -13,11 +13,11 @@ namespace QuantumCore.Game.Commands
         {
             _world = world;
         }
-        
+
         public async Task ExecuteAsync(CommandContext context)
         {
-            await context.Player.SendChatInfo("Logging out. Please wait.");
-            await _world.DespawnEntity(context.Player);
+            context.Player.SendChatInfo("Logging out. Please wait.");
+            _world.DespawnEntity(context.Player);
             context.Player.Disconnect();
         }
     }

--- a/Executables/Game/Commands/PhaseSelectCommand.cs
+++ b/Executables/Game/Commands/PhaseSelectCommand.cs
@@ -18,13 +18,13 @@ namespace QuantumCore.Game.Commands
 
         public async Task ExecuteAsync(CommandContext context)
         {
-            await context.Player.SendChatInfo("Going back to character selection. Please wait.");
+            context.Player.SendChatInfo("Going back to character selection. Please wait.");
 
             // todo implement wait
 
             // Despawn player
-            await _world.DespawnEntity(context.Player);
-            await context.Player.Connection.SetPhaseAsync(EPhases.Select);
+            _world.DespawnEntity(context.Player);
+            context.Player.Connection.SetPhaseAsync(EPhases.Select);
         }
     }
 }

--- a/Executables/Game/Commands/QuitCommand.cs
+++ b/Executables/Game/Commands/QuitCommand.cs
@@ -13,12 +13,12 @@ namespace QuantumCore.Game.Commands
         {
             _world = world;
         }
-        
+
         public async Task ExecuteAsync(CommandContext context)
         {
-            await context.Player.SendChatInfo("End the game. Please wait.");
-            await context.Player.SendChatCommand("quit");
-            await _world.DespawnEntity(context.Player);
+            context.Player.SendChatInfo("End the game. Please wait.");
+            context.Player.SendChatCommand("quit");
+            _world.DespawnEntity(context.Player);
             context.Player.Disconnect();
         }
     }

--- a/Executables/Game/Commands/RestartHereCommand.cs
+++ b/Executables/Game/Commands/RestartHereCommand.cs
@@ -8,7 +8,7 @@ namespace QuantumCore.Game.Commands
     {
         public async Task ExecuteAsync(CommandContext context)
         {
-            await context.Player.Respawn(false);
+            context.Player.Respawn(false);
         }
     }
 }

--- a/Executables/Game/Commands/RestartTownCommand.cs
+++ b/Executables/Game/Commands/RestartTownCommand.cs
@@ -8,6 +8,6 @@ public class RestartTownCommand : ICommandHandler
 {
     public async Task ExecuteAsync(CommandContext context)
     {
-        await context.Player.Respawn(true);
+        context.Player.Respawn(true);
     }
 }

--- a/Executables/Game/Commands/SpCommand.cs
+++ b/Executables/Game/Commands/SpCommand.cs
@@ -26,12 +26,12 @@ public class SpCommand : ICommandHandler<SpOtherOptions>
 
         if (target is null)
         {
-            await context.Player.SendChatMessage("Target not found!");
+            context.Player.SendChatMessage("Target not found!");
         }
         else
         {
-            await target.AddPoint(EPoints.Sp, context.Arguments.Value);
-            await target.SendPoints();   
+            target.AddPoint(EPoints.Sp, context.Arguments.Value);
+            target.SendPoints();
         }
     }
 }
@@ -41,7 +41,7 @@ public class SpOtherOptions
     [Value(0)]
     public int Value { get; set; }
 
-    [Value(1)] 
-    [CanBeNull] 
+    [Value(1)]
+    [CanBeNull]
     public string Target { get; set; }
 }

--- a/Executables/Game/Commands/SpawnCommand.cs
+++ b/Executables/Game/Commands/SpawnCommand.cs
@@ -23,13 +23,13 @@ namespace QuantumCore.Game.Commands
             _world = world;
             _logger = logger;
         }
-        
+
         public async Task ExecuteAsync(CommandContext<SpawnCommandOptions> context)
         {
             var proto = _monsterManager.GetMonster(context.Arguments.MonsterId);
             if (proto == null)
             {
-                await context.Player.SendChatInfo("No monster found with the specified id");
+                context.Player.SendChatInfo("No monster found with the specified id");
                 return;
             }
 
@@ -41,7 +41,7 @@ namespace QuantumCore.Game.Commands
 
                 // Create entity instance
                 var monster = new MonsterEntity(_monsterManager, _animationManager, _world, _logger, context.Arguments.MonsterId, x, y);
-                await _world.SpawnEntity(monster);
+                _world.SpawnEntity(monster);
             }
         }
     }

--- a/Executables/Game/Commands/StatCommand.cs
+++ b/Executables/Game/Commands/StatCommand.cs
@@ -14,10 +14,10 @@ public class StatCommand : ICommandHandler<StatCommandOptions>
         {
             return;
         }
-        
-        await context.Player.AddPoint(context.Arguments.Point, 1);
-        await context.Player.AddPoint(EPoints.StatusPoints, -1);
-        await context.Player.SendPoints();
+
+        context.Player.AddPoint(context.Arguments.Point, 1);
+        context.Player.AddPoint(EPoints.StatusPoints, -1);
+        context.Player.SendPoints();
     }
 }
 

--- a/Executables/Game/Extensions/ItemExtensions.cs
+++ b/Executables/Game/Extensions/ItemExtensions.cs
@@ -13,13 +13,54 @@ namespace QuantumCore.Extensions;
 
 public static class ItemExtensions
 {
-    public static uint GetMinWeaponDamage(this ItemData item)
+    public static uint GetMinWeaponBaseDamage(this ItemData item)
     {
         return (uint) item.Values[3];
     }
-    public static uint GetMaxWeaponDamage(this ItemData item)
+
+    public static uint GetMaxWeaponBaseDamage(this ItemData item)
     {
         return (uint) item.Values[4];
+    }
+
+    public static uint GetMinMagicWeaponBaseDamage(this ItemData item)
+    {
+        return (uint) item.Values[1];
+    }
+
+    public static uint GetMaxMagicWeaponBaseDamage(this ItemData item)
+    {
+        return (uint) item.Values[2];
+    }
+
+    /// <summary>
+    /// Weapon damage added additionally to the base damage
+    /// </summary>
+    /// <param name="item"></param>
+    /// <returns></returns>
+    public static uint GetAdditionalWeaponDamage(this ItemData item)
+    {
+        return (uint) item.Values[5];
+    }
+
+    public static uint GetMinWeaponDamage(this ItemData item)
+    {
+        return item.GetMinWeaponBaseDamage() + item.GetAdditionalWeaponDamage();
+    }
+
+    public static uint GetMaxWeaponDamage(this ItemData item)
+    {
+        return item.GetMaxWeaponBaseDamage() + item.GetAdditionalWeaponDamage();
+    }
+
+    public static uint GetMinMagicWeaponDamage(this ItemData item)
+    {
+        return item.GetMinMagicWeaponBaseDamage() + item.GetAdditionalWeaponDamage();
+    }
+
+    public static uint GetMaxMagicWeaponDamage(this ItemData item)
+    {
+        return item.GetMaxMagicWeaponBaseDamage() + item.GetAdditionalWeaponDamage();
     }
 
     public static EquipmentSlots? GetWearSlot(this IItemManager itemManager, ItemInstance item)

--- a/Executables/Game/Extensions/ItemExtensions.cs
+++ b/Executables/Game/Extensions/ItemExtensions.cs
@@ -4,13 +4,66 @@ using System.Data;
 using System.Threading.Tasks;
 using Dapper;
 using Dapper.Contrib.Extensions;
+using QuantumCore.API;
 using QuantumCore.API.Core.Models;
 using QuantumCore.Core.Cache;
+using QuantumCore.Game.PlayerUtils;
 
 namespace QuantumCore.Extensions;
 
 public static class ItemExtensions
 {
+    public static uint GetMinWeaponDamage(this ItemData item)
+    {
+        return (uint) item.Values[3];
+    }
+    public static uint GetMaxWeaponDamage(this ItemData item)
+    {
+        return (uint) item.Values[4];
+    }
+
+    public static EquipmentSlots? GetWearSlot(this IItemManager itemManager, ItemInstance item)
+    {
+        var proto = itemManager.GetItem(item.ItemId);
+        if (proto == null)
+        {
+            return null;
+        }
+
+        var wearFlags = (EWearFlags) proto.WearFlags;
+
+        if (wearFlags.HasFlag(EWearFlags.Head))
+        {
+            return EquipmentSlots.Head;
+        }
+        if (wearFlags.HasFlag(EWearFlags.Shoes))
+        {
+            return EquipmentSlots.Shoes;
+        }
+        if (wearFlags.HasFlag(EWearFlags.Bracelet))
+        {
+            return EquipmentSlots.Bracelet;
+        }
+        if (wearFlags.HasFlag(EWearFlags.Weapon))
+        {
+            return EquipmentSlots.Weapon;
+        }
+        if (wearFlags.HasFlag(EWearFlags.Necklace))
+        {
+            return EquipmentSlots.Necklace;
+        }
+        if (wearFlags.HasFlag(EWearFlags.Earrings))
+        {
+            return EquipmentSlots.Earring;
+        }
+        if (wearFlags.HasFlag(EWearFlags.Body))
+        {
+            return EquipmentSlots.Body;
+        }
+
+        return null;
+    }
+
     public static async Task<ItemInstance> GetItem(this IDbConnection db, ICacheManager cacheManager, Guid id)
     {
         var key = "item:" + id;

--- a/Executables/Game/Extensions/ServiceExtensions.cs
+++ b/Executables/Game/Extensions/ServiceExtensions.cs
@@ -26,6 +26,7 @@ public static class ServiceExtensions
         services.AddSingleton<IItemManager, ItemManager>();
         services.AddSingleton<IMonsterManager, MonsterManager>();
         services.AddSingleton<IJobManager, JobManager>();
+        services.AddSingleton<IAtlasProvider, AtlasProvider>();
         services.AddSingleton<IAnimationManager, AnimationManager>();
         services.AddSingleton<IExperienceManager, ExperienceManager>();
         services.AddSingleton<ICommandManager, CommandManager>();

--- a/Executables/Game/Extensions/ServiceExtensions.cs
+++ b/Executables/Game/Extensions/ServiceExtensions.cs
@@ -5,6 +5,8 @@ using QuantumCore.API.PluginTypes;
 using QuantumCore.Game.Commands;
 using QuantumCore.Game.PlayerUtils;
 using QuantumCore.Game.Quest;
+using QuantumCore.Game.Services;
+using QuantumCore.Game.World;
 
 namespace QuantumCore.Game.Extensions;
 
@@ -19,6 +21,8 @@ public static class ServiceExtensions
                 .AsImplementedInterfaces()
                 .WithSingletonLifetime();
         });
+        services.AddSingleton<ISpawnGroupProvider, SpawnGroupProvider>();
+        services.AddSingleton<ISpawnPointProvider, SpawnPointProvider>();
         services.AddSingleton<IItemManager, ItemManager>();
         services.AddSingleton<IMonsterManager, MonsterManager>();
         services.AddSingleton<IJobManager, JobManager>();

--- a/Executables/Game/Game.csproj
+++ b/Executables/Game/Game.csproj
@@ -11,6 +11,7 @@
 
     <ItemGroup>
       <PackageReference Include="CommandLineParser" Version="2.8.0" />
+      <PackageReference Include="Enums.NET" Version="4.0.1" />
     </ItemGroup>
 
     <ItemGroup>
@@ -19,6 +20,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="Core.Tests" />
       <None Update="appsettings.json">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>

--- a/Executables/Game/GameConnection.cs
+++ b/Executables/Game/GameConnection.cs
@@ -15,8 +15,8 @@ namespace QuantumCore.Game
         public string Username { get; set; }
         public IPlayerEntity Player { get; set; }
 
-        public GameConnection(IServerBase server, TcpClient client, ILogger<GameConnection> logger, 
-            PluginExecutor pluginExecutor, IWorld world, IPacketReader packetReader) 
+        public GameConnection(IServerBase server, TcpClient client, ILogger<GameConnection> logger,
+            PluginExecutor pluginExecutor, IWorld world, IPacketReader packetReader)
             : base(logger, pluginExecutor, packetReader)
         {
             _world = world;
@@ -33,11 +33,11 @@ namespace QuantumCore.Game
         {
             if (Player != null)
             {
-                await _world.DespawnEntity(Player);
+                _world.DespawnEntity(Player);
             }
 
             await Server.RemoveConnection(this);
-            
+
             // todo enable expiry on auth token
         }
 

--- a/Executables/Game/GameServer.cs
+++ b/Executables/Game/GameServer.cs
@@ -30,7 +30,7 @@ namespace QuantumCore.Game
         private readonly IQuestManager _questManager;
         private readonly IChatManager _chatManager;
         public IWorld World { get; }
-        
+
         private readonly Stopwatch _gameTime = new Stopwatch();
         private long _previousTicks = 0;
         private TimeSpan _accumulatedElapsedTime;
@@ -39,12 +39,12 @@ namespace QuantumCore.Game
         private readonly Stopwatch _serverTimer = new();
 
         public static GameServer Instance { get; private set; }
-        
-        public GameServer(IOptions<HostingOptions> hostingOptions, IPacketManager packetManager, 
-            ILogger<GameServer> logger, PluginExecutor pluginExecutor, IServiceProvider serviceProvider, 
-            IItemManager itemManager, IMonsterManager monsterManager, IExperienceManager experienceManager, 
+
+        public GameServer(IOptions<HostingOptions> hostingOptions, IPacketManager packetManager,
+            ILogger<GameServer> logger, PluginExecutor pluginExecutor, IServiceProvider serviceProvider,
+            IItemManager itemManager, IMonsterManager monsterManager, IExperienceManager experienceManager,
             IAnimationManager animationManager, ICommandManager commandManager,
-            IEnumerable<IPacketHandler> packetHandlers, IQuestManager questManager, IChatManager chatManager, 
+            IEnumerable<IPacketHandler> packetHandlers, IQuestManager questManager, IChatManager chatManager,
             IWorld world)
             : base(packetManager, logger, pluginExecutor, serviceProvider, packetHandlers, "game", hostingOptions)
         {
@@ -65,7 +65,7 @@ namespace QuantumCore.Game
         private void Update(double elapsedTime)
         {
             EventSystem.Update(elapsedTime);
-            
+
             World.Update(elapsedTime);
         }
 
@@ -81,16 +81,16 @@ namespace QuantumCore.Game
                 // Query interfaces for our best ipv4 address
                 IpUtils.SearchPublicIp();
             }
-            
+
             // Load game data
             await Task.WhenAll(
-                _itemManager.LoadAsync(stoppingToken), 
-                _monsterManager.LoadAsync(stoppingToken), 
+                _itemManager.LoadAsync(stoppingToken),
+                _monsterManager.LoadAsync(stoppingToken),
                 _experienceManager.LoadAsync(stoppingToken),
                 _animationManager.LoadAsync(stoppingToken),
                 _commandManager.LoadAsync(stoppingToken)
             );
-            
+
             // Initialize core systems
             _chatManager.Init();
 
@@ -98,32 +98,32 @@ namespace QuantumCore.Game
             _questManager.Init();
 
             // Load game world
-            _logger.LogInformation("Initialize world"); 
+            _logger.LogInformation("Initialize world");
             await World.Load();
 
             // Register all default commands
             _commandManager.Register("QuantumCore.Game.Commands");
-            
+
             // Put all new connections into login phase
-            RegisterNewConnectionListener(async connection =>
+            RegisterNewConnectionListener(connection =>
             {
-                await connection.SetPhaseAsync(EPhases.Login);
+                connection.SetPhaseAsync(EPhases.Login);
                 return true;
             });
 
             RegisterListeners();
-            
+
             // Start server timer
             _serverTimer.Start();
 
             _logger.LogInformation("Start listening for connections...");
 
             StartListening();
-            
+
             _gameTime.Start();
 
             _logger.LogDebug("Start!");
-            
+
             while (!stoppingToken.IsCancellationRequested)
             {
                 try
@@ -163,11 +163,11 @@ namespace QuantumCore.Game
             {
                 _accumulatedElapsedTime -= _targetElapsedTime;
                 ++stepCount;
-                
+
                 //_logger.LogDebug($"Update... ({stepCount})");
                 Update(_targetElapsedTime.TotalMilliseconds);
             }
-            
+
             // todo detect lags
         }
 

--- a/Executables/Game/PacketHandlers/Game/AttackHandler.cs
+++ b/Executables/Game/PacketHandlers/Game/AttackHandler.cs
@@ -13,7 +13,7 @@ public class AttackHandler : IGamePacketHandler<Attack>
     {
         _logger = logger;
     }
-        
+
     public async Task ExecuteAsync(GamePacketContext<Attack> ctx, CancellationToken token = default)
     {
         var attacker = ctx.Connection.Player;
@@ -23,15 +23,15 @@ public class AttackHandler : IGamePacketHandler<Attack>
             ctx.Connection.Close();
             return;
         }
-            
+
         var entity = attacker.Map.GetEntity(ctx.Packet.Vid);
         if (entity == null)
         {
             return;
         }
-            
+
         _logger.LogDebug("Attack from {Attacker} with type {AttackType} target {TargetId}", attacker.Name, ctx.Packet.AttackType, ctx.Packet.Vid);
 
-        await attacker.Attack(entity, 0);
+        attacker.Attack(entity, 0);
     }
 }

--- a/Executables/Game/PacketHandlers/Game/CharacterMoveHandler.cs
+++ b/Executables/Game/PacketHandlers/Game/CharacterMoveHandler.cs
@@ -14,7 +14,7 @@ public class CharacterMoveHandler : IGamePacketHandler<CharacterMove>
     {
         _logger = logger;
     }
-    
+
     public async Task ExecuteAsync(GamePacketContext<CharacterMove> ctx, CancellationToken token = default)
     {
         if (ctx.Packet.MovementType > (int) CharacterMove.CharacterMovementType.Max &&
@@ -24,14 +24,14 @@ public class CharacterMoveHandler : IGamePacketHandler<CharacterMove>
             ctx.Connection.Close();
             return;
         }
-            
+
         _logger.LogDebug("Received movement packet with type {MovementType}", (CharacterMove.CharacterMovementType)ctx.Packet.MovementType);
         if (ctx.Packet.MovementType == (int) CharacterMove.CharacterMovementType.Move)
         {
             ctx.Connection.Player.Rotation = ctx.Packet.Rotation * 5;
-            await ctx.Connection.Player.Goto(ctx.Packet.PositionX, ctx.Packet.PositionY);
+            ctx.Connection.Player.Goto(ctx.Packet.PositionX, ctx.Packet.PositionY);
         }
-            
+
         if (ctx.Packet.MovementType == (int) CharacterMove.CharacterMovementType.Wait)
         {
             ctx.Connection.Player.Wait(ctx.Packet.PositionX, ctx.Packet.PositionY);
@@ -50,13 +50,13 @@ public class CharacterMoveHandler : IGamePacketHandler<CharacterMove>
                 ? ctx.Connection.Player.MovementDuration
                 : 0
         };
-            
-        await ctx.Connection.Player.ForEachNearbyEntity(async entity =>
+
+        foreach (var entity in ctx.Connection.Player.NearbyEntities)
         {
             if(entity is PlayerEntity player)
             {
-                await player.Connection.Send(movement);
+                player.Connection.Send(movement);
             }
-        });
+        };
     }
 }

--- a/Executables/Game/PacketHandlers/Game/ItemDropHandler.cs
+++ b/Executables/Game/PacketHandlers/Game/ItemDropHandler.cs
@@ -18,7 +18,7 @@ public class ItemDropHandler : IGamePacketHandler<ItemDrop>
         if (ctx.Packet.Gold > 0)
         {
             // We're dropping gold...
-            await player.DropGold(ctx.Packet.Gold);
+            player.DropGold(ctx.Packet.Gold);
         }
         else
         {
@@ -29,7 +29,7 @@ public class ItemDropHandler : IGamePacketHandler<ItemDrop>
                 return; // Item slot is empty
             }
 
-            await player.DropItem(item, ctx.Packet.Count);
+            player.DropItem(item, ctx.Packet.Count);
         }
     }
 }

--- a/Executables/Game/PacketHandlers/Game/ItemMoveHandler.cs
+++ b/Executables/Game/PacketHandlers/Game/ItemMoveHandler.cs
@@ -13,7 +13,7 @@ public class ItemMoveHandler : IGamePacketHandler<ItemMove>
     {
         _logger = logger;
     }
-        
+
     public async Task ExecuteAsync(GamePacketContext<ItemMove> ctx, CancellationToken token = default)
     {
         var player = ctx.Connection.Player;
@@ -22,7 +22,7 @@ public class ItemMoveHandler : IGamePacketHandler<ItemMove>
             ctx.Connection.Close();
             return;
         }
-            
+
         _logger.LogDebug("Move item from {FromWindow},{FromPosition} to {ToWindow},{ToPosition}", ctx.Packet.FromWindow, ctx.Packet.FromPosition, ctx.Packet.ToWindow, ctx.Packet.ToPosition);
 
         // Get moved item
@@ -37,14 +37,14 @@ public class ItemMoveHandler : IGamePacketHandler<ItemMove>
         if (player.IsSpaceAvailable(item, ctx.Packet.ToWindow, ctx.Packet.ToPosition))
         {
             // remove from old space
-            await player.RemoveItem(item);
-                
+            player.RemoveItem(item);
+
             // place item
-            await player.SetItem(item, ctx.Packet.ToWindow, ctx.Packet.ToPosition);
+            player.SetItem(item, ctx.Packet.ToWindow, ctx.Packet.ToPosition);
 
             // send item movement to client
-            await player.SendRemoveItem(ctx.Packet.FromWindow, ctx.Packet.FromPosition);
-            await player.SendItem(item);
+            player.SendRemoveItem(ctx.Packet.FromWindow, ctx.Packet.FromPosition);
+            player.SendItem(item);
         }
     }
 }

--- a/Executables/Game/PacketHandlers/Game/ItemPickup.cs
+++ b/Executables/Game/PacketHandlers/Game/ItemPickup.cs
@@ -23,6 +23,6 @@ public class ItemPickupHandler : IGamePacketHandler<ItemPickup>
             return;
         }
 
-        await player.Pickup(groundItem);
+        player.Pickup(groundItem);
     }
 }

--- a/Executables/Game/PacketHandlers/Game/ItemUseHandler.cs
+++ b/Executables/Game/PacketHandlers/Game/ItemUseHandler.cs
@@ -59,7 +59,7 @@ public class ItemUseHandler : IGamePacketHandler<ItemUse>
         }
         else if (player.IsEquippable(item))
         {
-            var wearSlot = player.Inventory.EquipmentWindow.GetWearSlot(_itemManager, item);
+            var wearSlot = player.Inventory.EquipmentWindow.GetWearPosition(_itemManager, item);
 
             if (wearSlot <= ushort.MaxValue)
             {

--- a/Executables/Game/PacketHandlers/Game/ItemUseHandler.cs
+++ b/Executables/Game/PacketHandlers/Game/ItemUseHandler.cs
@@ -16,7 +16,7 @@ public class ItemUseHandler : IGamePacketHandler<ItemUse>
         _itemManager = itemManager;
         _logger = logger;
     }
-        
+
     public async Task ExecuteAsync(GamePacketContext<ItemUse> ctx, CancellationToken token = default)
     {
         var player = ctx.Connection.Player;
@@ -44,17 +44,17 @@ public class ItemUseHandler : IGamePacketHandler<ItemUse>
 
         if (ctx.Packet.Window == (byte) WindowType.Inventory && ctx.Packet.Position >= player.Inventory.Size)
         {
-            await player.RemoveItem(item);
+            player.RemoveItem(item);
             if (await player.Inventory.PlaceItem(item))
             {
-                await player.SendRemoveItem(ctx.Packet.Window, ctx.Packet.Position);
-                await player.SendItem(item);
-                await player.SendCharacterUpdate();
+                player.SendRemoveItem(ctx.Packet.Window, ctx.Packet.Position);
+                player.SendItem(item);
+                player.SendCharacterUpdate();
             }
             else
             {
-                await player.SetItem(item, ctx.Packet.Window, ctx.Packet.Position);
-                await player.SendChatInfo("Cannot unequip item if the inventory is full");
+                player.SetItem(item, ctx.Packet.Window, ctx.Packet.Position);
+                player.SendChatInfo("Cannot unequip item if the inventory is full");
             }
         }
         else if (player.IsEquippable(item))
@@ -67,30 +67,30 @@ public class ItemUseHandler : IGamePacketHandler<ItemUse>
 
                 if (item2 != null)
                 {
-                    await player.RemoveItem(item);
-                    await player.RemoveItem(item2);
+                    player.RemoveItem(item);
+                    player.RemoveItem(item2);
                     if (await player.Inventory.PlaceItem(item2))
                     {
-                        await player.SendRemoveItem(ctx.Packet.Window, (ushort)wearSlot);
-                        await player.SendRemoveItem(ctx.Packet.Window, ctx.Packet.Position);
-                        await player.SetItem(item, ctx.Packet.Window, (ushort)wearSlot);
-                        await player.SetItem(item2, ctx.Packet.Window, ctx.Packet.Position);
-                        await player.SendItem(item);
-                        await player.SendItem(item2);
+                        player.SendRemoveItem(ctx.Packet.Window, (ushort)wearSlot);
+                        player.SendRemoveItem(ctx.Packet.Window, ctx.Packet.Position);
+                        player.SetItem(item, ctx.Packet.Window, (ushort)wearSlot);
+                        player.SetItem(item2, ctx.Packet.Window, ctx.Packet.Position);
+                        player.SendItem(item);
+                        player.SendItem(item2);
                     }
                     else
                     {
-                        await player.SetItem(item, ctx.Packet.Window, ctx.Packet.Position);
-                        await player.SetItem(item2, ctx.Packet.Window, (ushort)wearSlot);
-                        await player.SendChatInfo("Cannot swap item if the inventory is full");
+                        player.SetItem(item, ctx.Packet.Window, ctx.Packet.Position);
+                        player.SetItem(item2, ctx.Packet.Window, (ushort)wearSlot);
+                        player.SendChatInfo("Cannot swap item if the inventory is full");
                     }
                 }
                 else
                 {
-                    await player.RemoveItem(item);
-                    await player.SetItem(item, (byte) WindowType.Inventory, (ushort)wearSlot);
-                    await player.SendRemoveItem(ctx.Packet.Window, ctx.Packet.Position);
-                    await player.SendItem(item);
+                    player.RemoveItem(item);
+                    player.SetItem(item, (byte) WindowType.Inventory, (ushort)wearSlot);
+                    player.SendRemoveItem(ctx.Packet.Window, ctx.Packet.Position);
+                    player.SendItem(item);
                 }
             }
         }

--- a/Executables/Game/PacketHandlers/Game/TargetChangeHandler.cs
+++ b/Executables/Game/PacketHandlers/Game/TargetChangeHandler.cs
@@ -13,7 +13,7 @@ public class TargetChangeHandler : IGamePacketHandler<TargetChange>
     {
         _logger = logger;
     }
-        
+
     public async Task ExecuteAsync(GamePacketContext<TargetChange> ctx, CancellationToken token = default)
     {
         var player = ctx.Connection.Player;
@@ -33,6 +33,6 @@ public class TargetChangeHandler : IGamePacketHandler<TargetChange>
         player.Target?.TargetedBy.Remove(player);
         player.Target = entity;
         entity.TargetedBy.Add(player);
-        await player.SendTarget();
+        player.SendTarget();
     }
 }

--- a/Executables/Game/PacketHandlers/Loading/EnterGameHandler.cs
+++ b/Executables/Game/PacketHandlers/Loading/EnterGameHandler.cs
@@ -18,7 +18,7 @@ namespace QuantumCore.Game.PacketHandlers.Loading
             _logger = logger;
             _world = world;
         }
-        
+
         public async Task ExecuteAsync(GamePacketContext<EnterGame> ctx, CancellationToken token = default)
         {
             var player = ctx.Connection.Player;
@@ -28,24 +28,24 @@ namespace QuantumCore.Game.PacketHandlers.Loading
                 ctx.Connection.Close();
                 return;
             }
-            
+
             // Enable game phase
-            await ctx.Connection.SetPhaseAsync(EPhases.Game);
-            
-            await ctx.Connection.Send(new GameTime { Time = (uint) ctx.Connection.Server.ServerTime });
-            await ctx.Connection.Send(new Channel { ChannelNo = 1 }); // todo
-            
+            ctx.Connection.SetPhaseAsync(EPhases.Game);
+
+            ctx.Connection.Send(new GameTime { Time = (uint) ctx.Connection.Server.ServerTime });
+            ctx.Connection.Send(new Channel { ChannelNo = 1 }); // todo
+
             // Show the player
-            await player.Show(ctx.Connection);
-            
+            player.Show(ctx.Connection);
+
             // Spawn the player
-            if (!await _world.SpawnEntity(player))
+            if (!_world.SpawnEntity(player))
             {
                 _logger.LogWarning("Failed to spawn player entity");
                 ctx.Connection.Close();
             }
-            
-            await player.SendInventory();
+
+            player.SendInventory();
         }
     }
 }

--- a/Executables/Game/PacketHandlers/Loading/EnterGameHandler.cs
+++ b/Executables/Game/PacketHandlers/Loading/EnterGameHandler.cs
@@ -35,15 +35,8 @@ namespace QuantumCore.Game.PacketHandlers.Loading
             ctx.Connection.Send(new GameTime { Time = (uint) ctx.Connection.Server.ServerTime });
             ctx.Connection.Send(new Channel { ChannelNo = 1 }); // todo
 
-            // Show the player
             player.Show(ctx.Connection);
-
-            // Spawn the player
-            if (!_world.SpawnEntity(player))
-            {
-                _logger.LogWarning("Failed to spawn player entity");
-                ctx.Connection.Close();
-            }
+            _world.SpawnEntity(player);
 
             player.SendInventory();
         }

--- a/Executables/Game/PacketHandlers/Select/DeleteCharacterHandler.cs
+++ b/Executables/Game/PacketHandlers/Select/DeleteCharacterHandler.cs
@@ -24,7 +24,7 @@ public class DeleteCharacterHandler : IGamePacketHandler<DeleteCharacter>
         _db = db;
         _cacheManager = cacheManager;
     }
-    
+
     public async Task ExecuteAsync(GamePacketContext<DeleteCharacter> ctx, CancellationToken token = default)
     {
         _logger.LogDebug("Deleting character in slot {Slot}", ctx.Packet.Slot);
@@ -49,11 +49,11 @@ public class DeleteCharacterHandler : IGamePacketHandler<DeleteCharacter>
 
         if (deletecode != ctx.Packet.Code[..^1])
         {
-            await ctx.Connection.Send(new DeleteCharacterFail());
+            ctx.Connection.Send(new DeleteCharacterFail());
             return;
         }
 
-        await ctx.Connection.Send(new DeleteCharacterSuccess
+        ctx.Connection.Send(new DeleteCharacterSuccess
         {
             Slot = ctx.Packet.Slot
         });

--- a/Executables/Game/PacketHandlers/Select/SelectGameCharacterHandler.cs
+++ b/Executables/Game/PacketHandlers/Select/SelectGameCharacterHandler.cs
@@ -19,7 +19,7 @@ public class SelectGameCharacterHandler : IGamePacketHandler<SelectCharacter>
     private readonly IServiceProvider _provider;
     private readonly ICacheManager _cacheManager;
 
-    public SelectGameCharacterHandler(IDbConnection db, ILogger<SelectGameCharacterHandler> logger, IServiceProvider provider, 
+    public SelectGameCharacterHandler(IDbConnection db, ILogger<SelectGameCharacterHandler> logger, IServiceProvider provider,
         ICacheManager cacheManager)
     {
         _db = db;
@@ -27,7 +27,7 @@ public class SelectGameCharacterHandler : IGamePacketHandler<SelectCharacter>
         _provider = provider;
         _cacheManager = cacheManager;
     }
-    
+
     public async Task ExecuteAsync(GamePacketContext<SelectCharacter> ctx, CancellationToken token = default)
     {
         _logger.LogDebug("Selected character in slot {Slot}", ctx.Packet.Slot);
@@ -42,7 +42,7 @@ public class SelectGameCharacterHandler : IGamePacketHandler<SelectCharacter>
         var accountId = ctx.Connection.AccountId ?? default; // todo clean solution
 
         // Let the client load the game
-        await ctx.Connection.SetPhaseAsync(EPhases.Loading);
+        ctx.Connection.SetPhaseAsync(EPhases.Loading);
 
         // Load player
         var player = await Player.GetPlayer(_db, _cacheManager, accountId, ctx.Packet.Slot);
@@ -52,9 +52,9 @@ public class SelectGameCharacterHandler : IGamePacketHandler<SelectCharacter>
         ctx.Connection.Player = entity;
 
         // Send information about the player to the client
-        await entity.SendBasicData();
-        await entity.SendPoints();
-        await entity.SendCharacterUpdate();
+        entity.SendBasicData();
+        entity.SendPoints();
+        entity.SendCharacterUpdate();
         await entity.QuickSlotBar.Send();
     }
 }

--- a/Executables/Game/PacketHandlers/StateCheckPacketHandler.cs
+++ b/Executables/Game/PacketHandlers/StateCheckPacketHandler.cs
@@ -10,7 +10,7 @@ public class StateCheckPacketHandler : IGamePacketHandler<StateCheckPacket>
 {
     public async Task ExecuteAsync(GamePacketContext<StateCheckPacket> ctx, CancellationToken token = default)
     {
-        await ctx.Connection.Send(new ServerStatusPacket {
+        ctx.Connection.Send(new ServerStatusPacket {
             Statuses = new [] {
                 new ServerStatus {
                     Port = 13001,

--- a/Executables/Game/ParserUtils.cs
+++ b/Executables/Game/ParserUtils.cs
@@ -1,0 +1,112 @@
+﻿using System.Text.RegularExpressions;
+using EnumsNET;
+using QuantumCore.API.Game.World;
+using QuantumCore.Game.World;
+
+namespace QuantumCore.Game;
+
+internal static partial class ParserUtils
+{
+    public static SpawnPoint GetSpawnFromLine(string line)
+    {
+        // r	751	311	10	10	0	0	5s	100	1	101
+        var splitted = SplitByWhitespaceRegex().Split(line);
+        return new SpawnPoint
+        {
+            Type = Enums.Parse<ESpawnPointType>(splitted[0][..1], true, EnumFormat.EnumMemberValue),
+            IsAggressive = splitted[0].Length > 1 && splitted[0][1..2].Equals("a", StringComparison.InvariantCultureIgnoreCase),
+            X = int.Parse(splitted[1]),
+            Y = int.Parse(splitted[2]),
+            RangeX = int.Parse(splitted[3]),
+            RangeY = int.Parse(splitted[4]),
+            Direction = int.Parse(splitted[5]),
+            // splitted[6],
+            RespawnTime = ParseSecondsFromTimespanString(splitted[7]),
+            Chance = short.Parse(splitted[8]),
+            MaxAmount = short.Parse(splitted[9]),
+            Monster = uint.Parse(splitted[10])
+        };
+    }
+
+    private static int ParseSecondsFromTimespanString(string str)
+    {
+        var value = int.Parse(str[..^1]);
+        if (str.EndsWith("s", StringComparison.InvariantCultureIgnoreCase))
+        {
+            return value;
+        }
+        if (str.EndsWith("m", StringComparison.InvariantCultureIgnoreCase))
+        {
+            return value * 60;
+        }
+        if (str.EndsWith("h", StringComparison.InvariantCultureIgnoreCase))
+        {
+            return value * 3600;
+        }
+
+        throw new ArgumentOutOfRangeException(nameof(str), $"Don't know how to parse \"{str}\" to TimeSpan");
+    }
+
+    public static async Task<SpawnGroup?> GetSpawnGroupFromBlock(TextReader sr)
+    {
+        var item = new SpawnGroup();
+        string? line;
+        do
+        {
+            line = await sr.ReadLineAsync();
+            if (line is null) return null; // EOS
+        } while (!line.StartsWith("Group"));
+        item.Name = GroupReplaceRegex().Replace(line, "", 1).Trim();
+        await sr.ReadLineAsync();
+        line = (await sr.ReadLineAsync())!;
+        item.Id = uint.Parse(line.Replace("Vnum", "").Trim());
+        line = (await sr.ReadLineAsync())!;
+        item.Leader = uint.Parse(SplitByWhitespaceRegex().Split(LeaderReplaceRegex().Replace(line, "", 1).Trim())[1].Trim());
+        while ((line = (await sr.ReadLineAsync())!.Trim()) != "}")
+        {
+            if (string.IsNullOrWhiteSpace(line)) break;
+            item.Members.Add(new SpawnMember
+            {
+                Id = uint.Parse(SplitByWhitespaceRegex().Split(line)[^1].Trim())
+            });
+        }
+
+        return item;
+    }
+
+    public static async Task<SpawnGroupCollection?> GetSpawnGroupCollectionFromBlock(TextReader sr)
+    {
+        var item = new SpawnGroupCollection();
+        string? line;
+        do
+        {
+            line = await sr.ReadLineAsync();
+            if (line is null) return null; // EOS
+        } while (!line.StartsWith("Group"));
+        item.Name = GroupReplaceRegex().Replace(line, "", 1).Trim();
+        await sr.ReadLineAsync();
+        line = (await sr.ReadLineAsync())!;
+        item.Id = uint.Parse(line.Replace("Vnum", "").Trim());
+        while ((line = (await sr.ReadLineAsync())!.Trim()) != "}")
+        {
+            if (string.IsNullOrWhiteSpace(line)) break;
+            var splitted = SplitByWhitespaceRegex().Split(line);
+            item.Members.Add(new SpawnGroupCollectionMember
+            {
+                Id = uint.Parse(splitted[^2].Trim()),
+                Amount = byte.Parse(splitted[^1].Trim())
+            });
+        }
+
+        return item;
+    }
+
+    [GeneratedRegex("(?: {2,}|\\t+)")]
+    private static partial Regex SplitByWhitespaceRegex();
+
+    [GeneratedRegex("Leader")]
+    private static partial Regex LeaderReplaceRegex();
+
+    [GeneratedRegex("Group")]
+    private static partial Regex GroupReplaceRegex();
+}

--- a/Executables/Game/PlayerUtils/Equipment.cs
+++ b/Executables/Game/PlayerUtils/Equipment.cs
@@ -137,39 +137,39 @@ namespace QuantumCore.Game.PlayerUtils
         {
             if (Body != null)
             {
-                await player.SendItem(Body);
+                player.SendItem(Body);
             }
             if (Head != null)
             {
-                await player.SendItem(Head);
+                player.SendItem(Head);
             }
             if (Shoes != null)
             {
-                await player.SendItem(Shoes);
+                player.SendItem(Shoes);
             }
             if (Bracelet != null)
             {
-                await player.SendItem(Bracelet);
+                player.SendItem(Bracelet);
             }
             if (Weapon != null)
             {
-                await player.SendItem(Weapon);
+                player.SendItem(Weapon);
             }
             if (Necklace != null)
             {
-                await player.SendItem(Necklace);
+                player.SendItem(Necklace);
             }
             if (Earrings != null)
             {
-                await player.SendItem(Earrings);
+                player.SendItem(Earrings);
             }
             if (Costume != null)
             {
-                await player.SendItem(Costume);
+                player.SendItem(Costume);
             }
             if (Hair != null)
             {
-                await player.SendItem(Hair);
+                player.SendItem(Hair);
             }
         }
 
@@ -182,7 +182,7 @@ namespace QuantumCore.Game.PlayerUtils
             }
 
             var wearFlags = (EWearFlags) proto.WearFlags;
-            
+
             switch ((EquipmentSlots)(position - _offset))
             {
                 case EquipmentSlots.Body:
@@ -217,7 +217,7 @@ namespace QuantumCore.Game.PlayerUtils
             }
 
             var wearFlags = (EWearFlags) proto.WearFlags;
-            
+
             if (wearFlags.HasFlag(EWearFlags.Head))
                 return _offset + (ushort)EquipmentSlots.Head;
             else if (wearFlags.HasFlag(EWearFlags.Shoes))

--- a/Executables/Game/PlayerUtils/Equipment.cs
+++ b/Executables/Game/PlayerUtils/Equipment.cs
@@ -208,7 +208,7 @@ namespace QuantumCore.Game.PlayerUtils
             }
         }
 
-        public long GetWearSlot(IItemManager itemManager, ItemInstance item)
+        public long GetWearPosition(IItemManager itemManager, ItemInstance item)
         {
             var proto = itemManager.GetItem(item.ItemId);
             if (proto == null)

--- a/Executables/Game/PlayerUtils/Inventory.cs
+++ b/Executables/Game/PlayerUtils/Inventory.cs
@@ -337,5 +337,11 @@ namespace QuantumCore.Game.PlayerUtils
                 Log.Debug("Failed to place item");
             }
         }
+
+        public void SetEquipment(ItemInstance item, ushort position)
+        {
+            EquipmentWindow.SetItem(item, position);
+            OnSlotChanged?.Invoke(this, new SlotChangedEventArgs(item, _itemManager.GetWearSlot(item)!.Value));
+        }
     }
 }

--- a/Executables/Game/PlayerUtils/Inventory.cs
+++ b/Executables/Game/PlayerUtils/Inventory.cs
@@ -14,7 +14,7 @@ namespace QuantumCore.Game.PlayerUtils
     {
         Inventory = 1
     }
-    
+
     public class Inventory : IInventory
     {
         private class Page
@@ -30,7 +30,7 @@ namespace QuantumCore.Game.PlayerUtils
                 _itemManager = itemManager;
                 _width = width;
                 _height = height;
-                
+
                 _grid = new Grid<ItemInstance>(_width, _height);
             }
 
@@ -38,7 +38,7 @@ namespace QuantumCore.Game.PlayerUtils
             {
                 if (position < 0) return null;
                 if (position >= _width * _height) return null;
-                
+
                 var x = (uint)(position % _width);
                 var y = (uint)(position / _width);
 
@@ -49,13 +49,13 @@ namespace QuantumCore.Game.PlayerUtils
             {
                 if (position < 0) return false;
                 if (position >= _width * _height) return false;
-                
+
                 var x = (uint)(position % _width);
                 var y = (uint)(position / _width);
 
                 var item = _grid.Get(x, y);
                 if (item == null) return false;
-                
+
                 var proto = _itemManager.GetItem(item.ItemId);
                 if (proto == null) return false;
 
@@ -80,7 +80,7 @@ namespace QuantumCore.Game.PlayerUtils
                     for (uint x = 0; x < _width; x++)
                     {
                         if (Place(item, x, y)) return x + y * _width;
-                    }    
+                    }
                 }
 
                 return -1;
@@ -100,7 +100,7 @@ namespace QuantumCore.Game.PlayerUtils
                 {
                     _grid.Set(x, y + i, item);
                 }
-                
+
                 return true;
             }
 
@@ -119,7 +119,7 @@ namespace QuantumCore.Game.PlayerUtils
             {
                 if (position < 0) return false;
                 if (position >= _width * _height) return false;
-                
+
                 var x = (uint)(position % _width);
                 var y = (uint)(position / _width);
 
@@ -134,7 +134,7 @@ namespace QuantumCore.Game.PlayerUtils
                 for (byte i = 0; i < size; i++)
                 {
                     if (y + i >= _height) return false;
-                    
+
                     if (_grid.Get(x, y + i) != null)
                     {
                         return false;
@@ -144,15 +144,19 @@ namespace QuantumCore.Game.PlayerUtils
                 return true;
             }
         }
-        
+
+        public event EventHandler<SlotChangedEventArgs>? OnSlotChanged;
         public Guid Owner { get; private set; }
         public byte Window { get; private set; }
+
         public ReadOnlyCollection<ItemInstance> Items {
             get {
                 return _items.AsReadOnly();
             }
         }
+
         public IEquipment EquipmentWindow { get; private set; }
+
 
         public long Size {
             get {
@@ -169,7 +173,7 @@ namespace QuantumCore.Game.PlayerUtils
         private readonly ICacheManager _cacheManager;
         private readonly ILogger _logger;
 
-        public Inventory(IItemManager itemManager, IDbConnection db, ICacheManager cacheManager, ILogger logger, 
+        public Inventory(IItemManager itemManager, IDbConnection db, ICacheManager cacheManager, ILogger logger,
             Guid owner, byte window, ushort width, ushort height, ushort pages)
         {
             Owner = owner;
@@ -188,7 +192,7 @@ namespace QuantumCore.Game.PlayerUtils
             {
                 _pages[i] = new Page(_itemManager, width, height);
             }
-            
+
             // Initialize equipment
             EquipmentWindow = new Equipment(Owner, Size);
         }
@@ -196,7 +200,7 @@ namespace QuantumCore.Game.PlayerUtils
         public async Task Load()
         {
             _items.Clear();
-            
+
             var pageSize = _width * _height;
             await foreach(var item in _db.GetItems(_cacheManager, Owner, Window))
             {
@@ -228,7 +232,7 @@ namespace QuantumCore.Game.PlayerUtils
             for(var i = 0; i < _pages.Length; i++)
             {
                 var page = _pages[i];
-                
+
                 var pos = page.Place(instance);
                 if (pos != -1)
                 {
@@ -255,6 +259,13 @@ namespace QuantumCore.Game.PlayerUtils
             {
                 _items.Add(item);
                 await item.Set(_cacheManager, Owner, Window, position);
+                var wearSlot = _itemManager.GetWearSlot(item);
+                if (wearSlot is not null && position == EquipmentWindow.GetWearPosition(_itemManager, item))
+                {
+                    // if item is now "equipped"
+                    // TODO write test
+                    OnSlotChanged?.Invoke(this, new SlotChangedEventArgs(item, wearSlot.Value));
+                }
                 return true;
             }
 

--- a/Executables/Game/PlayerUtils/QuickSlotBar.cs
+++ b/Executables/Game/PlayerUtils/QuickSlotBar.cs
@@ -15,7 +15,7 @@ public class QuickSlotBar : IQuickSlotBar
     private readonly ILogger _logger;
     public IPlayerEntity Player { get; }
     public QuickSlotData[] Slots { get; } = new QuickSlotData[8];
-    
+
     public QuickSlotBar(ICacheManager cacheManager, ILogger logger, PlayerEntity player)
     {
         _cacheManager = cacheManager;
@@ -26,7 +26,7 @@ public class QuickSlotBar : IQuickSlotBar
     public async Task Load()
     {
         var key = $"quickbar:{Player.Player.Id}";
-        
+
         if (await _cacheManager.Exists(key) > 0)
         {
             var slots = await _cacheManager.Get<QuickSlotData[]>(key);
@@ -43,7 +43,7 @@ public class QuickSlotBar : IQuickSlotBar
                 }
             }
         }
-        
+
         // todo load from database
     }
 
@@ -63,8 +63,8 @@ public class QuickSlotBar : IQuickSlotBar
             {
                 continue;
             }
-            
-            await Player.Connection.Send(new QuickBarAddOut {
+
+            Player.Connection.Send(new QuickBarAddOut {
                 Position = (byte) i,
                 Slot = new QuickSlot{Position = slot.Position, Type = slot.Type}
             });
@@ -79,9 +79,9 @@ public class QuickSlotBar : IQuickSlotBar
         }
 
         // todo verify type, and position?
-        
+
         Slots[position] = slot;
-        await Player.Connection.Send(new QuickBarAddOut {
+        Player.Connection.Send(new QuickBarAddOut {
             Position = position,
             Slot = new QuickSlot{Position = slot.Position, Type = slot.Type}
         });
@@ -98,7 +98,7 @@ public class QuickSlotBar : IQuickSlotBar
         var slot2 = Slots[position2];
         Slots[position1] = slot2;
         Slots[position2] = slot1;
-        await Player.Connection.Send(new QuickBarSwapOut {
+        Player.Connection.Send(new QuickBarSwapOut {
             Position1 = position1,
             Position2 = position2
         });
@@ -112,7 +112,7 @@ public class QuickSlotBar : IQuickSlotBar
         }
 
         Slots[position] = null;
-        await Player.Connection.Send(new QuickBarRemoveOut {
+        Player.Connection.Send(new QuickBarRemoveOut {
             Position = position
         });
     }

--- a/Executables/Game/Quest/Quest.cs
+++ b/Executables/Game/Quest/Quest.cs
@@ -30,7 +30,7 @@ public abstract class Quest : IQuest
 
     protected async Task SendScript()
     {
-        await _player.Connection.Send(new QuestScript {
+        _player.Connection.Send(new QuestScript {
             Skin = (byte) _currentSkin,
             Source = _questScript
         });
@@ -43,7 +43,7 @@ public abstract class Quest : IQuest
     {
         _currentSkin = skin;
     }
-    
+
     public void Answer(byte answer)
     {
         if (answer == 254)
@@ -51,7 +51,7 @@ public abstract class Quest : IQuest
             _currentNextTask.SetResult();
             return;
         }
-        
+
         _currentChoiceTask.SetResult(answer);
     }
 
@@ -64,29 +64,29 @@ public abstract class Quest : IQuest
     {
         _currentNextTask?.TrySetCanceled();
         _currentNextTask = new TaskCompletionSource();
-        
+
         _questScript += "[NEXT]";
         await SendScript();
-        
+
         _player.CurrentQuest = this;
     }
 
     protected async Task<byte> Choice(bool done = false, params string[] options)
     {
         Debug.Assert(options.Length > 0);
-        
+
         _currentChoiceTask?.TrySetCanceled();
         _currentChoiceTask = new TaskCompletionSource<byte>();
 
         _questScript += "[QUESTION ";
-        
+
         for (var i = 0; i < options.Length; i++)
         {
             if (i != 0)
             {
                 _questScript += "|";
             }
-            
+
             Debug.Assert(!options[i].Contains(';'));
             Debug.Assert(!options[i].Contains('|'));
 
@@ -99,7 +99,7 @@ public abstract class Quest : IQuest
         {
             _questScript += "[DONE]";
         }
-        
+
         await SendScript();
 
         _player.CurrentQuest = this;
@@ -113,7 +113,7 @@ public abstract class Quest : IQuest
             _questScript += "[ENTER]";
         }
         _questScript += "[DONE]";
-        
+
         await SendScript();
     }
 }

--- a/Executables/Game/Services/AtlasProvider.cs
+++ b/Executables/Game/Services/AtlasProvider.cs
@@ -1,0 +1,101 @@
+﻿using System.Text.RegularExpressions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using QuantumCore.API;
+using QuantumCore.API.Game.World;
+using QuantumCore.Core.Cache;
+using QuantumCore.Game.World;
+
+namespace QuantumCore.Game.Services;
+
+internal class AtlasProvider : IAtlasProvider
+{
+    private readonly IConfiguration _configuration;
+    private readonly IMonsterManager _monsterManager;
+    private readonly IAnimationManager _animationManager;
+    private readonly ISpawnPointProvider _spawnPointProvider;
+    private readonly IOptions<HostingOptions> _options;
+    private readonly ICacheManager _cacheManager;
+    private readonly ILogger<AtlasProvider> _logger;
+
+    public AtlasProvider(IConfiguration configuration, IMonsterManager monsterManager,
+        IAnimationManager animationManager, ISpawnPointProvider spawnPointProvider, IOptions<HostingOptions> options,
+        ICacheManager cacheManager, ILogger<AtlasProvider> logger)
+    {
+        _configuration = configuration;
+        _monsterManager = monsterManager;
+        _animationManager = animationManager;
+        _spawnPointProvider = spawnPointProvider;
+        _options = options;
+        _cacheManager = cacheManager;
+        _logger = logger;
+    }
+
+    public async Task<IEnumerable<IMap>> GetAsync(IWorld world)
+    {
+        // Regex for parsing lines in the atlas info
+        var regex = new Regex(@"^([a-zA-Z0-9\/_]+)[\s]+([0-9]+)[\s]+([0-9]+)[\s]+([0-9]+)[\s]+([0-9]+)$");
+
+        var maxX = 0u;
+        var maxY = 0u;
+
+        // Load atlasinfo.txt and initialize all maps the game core hosts
+        if (!File.Exists("data/atlasinfo.txt"))
+        {
+            throw new FileNotFoundException("Unable to find file data/atlasinfo.txt");
+        }
+
+        var maps = _configuration.GetSection("maps").Get<string[]>() ?? Array.Empty<string>();
+        var returnList = new List<IMap>();
+        using var reader = new StreamReader("data/atlasinfo.txt");
+        string line;
+        var lineNo = 0;
+        while ((line = (await reader.ReadLineAsync())!) != null)
+        {
+            lineNo++;
+            if (string.IsNullOrWhiteSpace(line)) continue; // skip empty lines
+
+            var match = regex.Match(line);
+            if (match.Success)
+            {
+                try
+                {
+                    var mapName = match.Groups[1].Value;
+                    var positionX = uint.Parse(match.Groups[2].Value);
+                    var positionY = uint.Parse(match.Groups[3].Value);
+                    var width = uint.Parse(match.Groups[4].Value);
+                    var height = uint.Parse(match.Groups[5].Value);
+
+                    IMap map;
+                    if (!maps.Contains(mapName))
+                    {
+                        map = new RemoteMap(mapName, positionX, positionY, width, height);
+                    }
+                    else
+                    {
+                        map = new Map(_monsterManager, _animationManager, _cacheManager, world, _options, _logger,
+                            _spawnPointProvider, mapName, positionX, positionY, width, height);
+                    }
+
+
+                    returnList.Add(map);
+
+                    if (positionX + width * Map.MapUnit > maxX) maxX = positionX + width * Map.MapUnit;
+                    if (positionY + height * Map.MapUnit > maxY) maxY = positionY + height * Map.MapUnit;
+                }
+                catch (FormatException)
+                {
+                    throw new InvalidDataException(
+                        $"Failed to parse atlasinfo.txt:line {lineNo} - Failed to parse number");
+                }
+            }
+            else
+            {
+                throw new InvalidDataException($"Failed to parse atlasinfo.txt:line {lineNo} - Failed to parse line");
+            }
+        }
+
+        return returnList;
+    }
+}

--- a/Executables/Game/Services/IAtlasProvider.cs
+++ b/Executables/Game/Services/IAtlasProvider.cs
@@ -1,0 +1,8 @@
+﻿using QuantumCore.API.Game.World;
+
+namespace QuantumCore.Game.Services;
+
+public interface IAtlasProvider
+{
+    Task<IEnumerable<IMap>> GetAsync(IWorld world);
+}

--- a/Executables/Game/Services/ISpawnGroupProvider.cs
+++ b/Executables/Game/Services/ISpawnGroupProvider.cs
@@ -1,0 +1,9 @@
+﻿using QuantumCore.API.Game.World;
+
+namespace QuantumCore.Game.Services;
+
+public interface ISpawnGroupProvider
+{
+    Task<IEnumerable<SpawnGroup>> GetSpawnGroupsAsync();
+    Task<IEnumerable<SpawnGroupCollection>> GetSpawnGroupCollectionsAsync();
+}

--- a/Executables/Game/Services/ISpawnPointProvider.cs
+++ b/Executables/Game/Services/ISpawnPointProvider.cs
@@ -1,0 +1,8 @@
+﻿using QuantumCore.Game.World;
+
+namespace QuantumCore.Game.Services;
+
+public interface ISpawnPointProvider
+{
+    Task<SpawnPoint[]> GetSpawnPointsForMap(string name);
+}

--- a/Executables/Game/Services/SpawnGroupProvider.cs
+++ b/Executables/Game/Services/SpawnGroupProvider.cs
@@ -1,0 +1,38 @@
+﻿using QuantumCore.API.Game.World;
+
+namespace QuantumCore.Game.Services;
+
+internal class SpawnGroupProvider : ISpawnGroupProvider
+{
+    public async Task<IEnumerable<SpawnGroup>> GetSpawnGroupsAsync()
+    {
+        const string file = "data/group.txt";
+        if (!File.Exists(file)) return Array.Empty<SpawnGroup>();
+
+        var list = new List<SpawnGroup>();
+        using var sr = new StreamReader(file);
+        do
+        {
+            var item = await Game.ParserUtils.GetSpawnGroupFromBlock(sr);
+            list.Add(item);
+        } while (!sr.EndOfStream);
+
+        return list;
+    }
+
+    public async Task<IEnumerable<SpawnGroupCollection>> GetSpawnGroupCollectionsAsync()
+    {
+        const string file = "data/group_group.txt";
+        if (!File.Exists(file)) return Array.Empty<SpawnGroupCollection>();
+
+        var list = new List<SpawnGroupCollection>();
+        using var sr = new StreamReader(file);
+        do
+        {
+            var item = await Game.ParserUtils.GetSpawnGroupCollectionFromBlock(sr);
+            list.Add(item);
+        } while (!sr.EndOfStream);
+
+        return list;
+    }
+}

--- a/Executables/Game/Services/SpawnPointProvider.cs
+++ b/Executables/Game/Services/SpawnPointProvider.cs
@@ -1,0 +1,26 @@
+﻿using QuantumCore.Game.World;
+
+namespace QuantumCore.Game.Services;
+
+internal class SpawnPointProvider : ISpawnPointProvider
+{
+    public async Task<SpawnPoint[]> GetSpawnPointsForMap(string name)
+    {
+        var filePath = $"data/maps/{name}/regen.txt";
+        if (!File.Exists(filePath)) return Array.Empty<SpawnPoint>();
+
+        using var sr = new StreamReader(filePath);
+
+        var list = new List<SpawnPoint>();
+        do
+        {
+            var line = await sr.ReadLineAsync();
+            if (line is null) break;
+
+            var spawn = Game.ParserUtils.GetSpawnFromLine(line);
+            list.Add(spawn);
+        } while (!sr.EndOfStream);
+
+        return list.ToArray();
+    }
+}

--- a/Executables/Game/World/AI/SimpleBehaviour.cs
+++ b/Executables/Game/World/AI/SimpleBehaviour.cs
@@ -154,7 +154,7 @@ namespace QuantumCore.Game.World.AI
             monster.Rotation =
                 (float) MathUtils.Rotation(victim.PositionX - monster.PositionX, victim.PositionY - monster.PositionY);
 
-            await monster.Attack(victim, monster.Proto.BattleType);
+            monster.Attack(victim, monster.Proto.BattleType);
 
             // Send attack packet
             var packet = new CharacterMoveOut {
@@ -165,13 +165,13 @@ namespace QuantumCore.Game.World.AI
                 PositionY = monster.PositionY,
                 Time = (uint) GameServer.Instance.ServerTime
             };
-            await monster.ForEachNearbyEntity(async entity =>
+            foreach (var entity in monster.NearbyEntities)
             {
                 if (entity is PlayerEntity player)
                 {
-                    await player.Connection.Send(packet);
+                    player.Connection.Send(packet);
                 }
-            });
+            }
         }
 
         private IEntity NextTarget()

--- a/Executables/Game/World/AI/SimpleBehaviour.cs
+++ b/Executables/Game/World/AI/SimpleBehaviour.cs
@@ -81,7 +81,7 @@ namespace QuantumCore.Game.World.AI
             _entity.Goto((int) targetPositionX, (int) targetPositionY);
         }
 
-        public async Task Update(double elapsedTime)
+        public void Update(double elapsedTime)
         {
             if (_entity == null)
             {
@@ -123,7 +123,7 @@ namespace QuantumCore.Game.World.AI
                             _attackCooldown -= elapsedTime;
                             if (_attackCooldown <= 0)
                             {
-                                await Attack(_targetEntity);
+                                Attack(_targetEntity).Wait(); // TODO
                                 _attackCooldown += 2000; // todo use attack speed
                             }
                         }

--- a/Executables/Game/World/Entities/Entity.cs
+++ b/Executables/Game/World/Entities/Entity.cs
@@ -85,7 +85,7 @@ namespace QuantumCore.Game.World.Entities
 
         protected abstract void OnNewNearbyEntity(IEntity entity);
         protected abstract void OnRemoveNearbyEntity(IEntity entity);
-        public abstract ValueTask OnDespawn();
+        public abstract void OnDespawn();
         public abstract void ShowEntity(IConnection connection);
         public abstract void HideEntity(IConnection connection);
 

--- a/Executables/Game/World/Entities/Entity.cs
+++ b/Executables/Game/World/Entities/Entity.cs
@@ -49,14 +49,14 @@ namespace QuantumCore.Game.World.Entities
         public long Mana { get; set; }
         public abstract byte HealthPercentage { get; }
         public bool Dead { get; protected set; }
-        
+
         public IMap Map { get; set; }
-        
+
         // QuadTree cache
         public int LastPositionX { get; set; }
         public int LastPositionY { get; set; }
         public IQuadTree LastQuadTree { get; set; }
-        
+
         // Movement related
         public long MovementStart { get; private set; }
         public int TargetPositionX { get; private set; }
@@ -66,7 +66,8 @@ namespace QuantumCore.Game.World.Entities
         public uint MovementDuration { get; private set; }
         public byte MovementSpeed { get; protected set; }
 
-        private List<IEntity> NearbyEntities { get; } = new();
+        public IReadOnlyCollection<IEntity> NearbyEntities => _nearbyEntities;
+        private List<IEntity> _nearbyEntities = new();
         public List<IPlayerEntity> TargetedBy { get; } = new();
         public const int ViewDistance = 10000;
 
@@ -82,13 +83,13 @@ namespace QuantumCore.Game.World.Entities
             Vid = vid;
         }
 
-        protected abstract ValueTask OnNewNearbyEntity(IEntity entity);
-        protected abstract ValueTask OnRemoveNearbyEntity(IEntity entity);
+        protected abstract void OnNewNearbyEntity(IEntity entity);
+        protected abstract void OnRemoveNearbyEntity(IEntity entity);
         public abstract ValueTask OnDespawn();
-        public abstract Task ShowEntity(IConnection connection);
-        public abstract Task HideEntity(IConnection connection);
-        
-        public virtual Task Update(double elapsedTime)
+        public abstract void ShowEntity(IConnection connection);
+        public abstract void HideEntity(IConnection connection);
+
+        public virtual void Update(double elapsedTime)
         {
             if (State == EEntityState.Moving)
             {
@@ -107,24 +108,21 @@ namespace QuantumCore.Game.World.Entities
                     State = EEntityState.Idle;
                 }
             }
-
-            return Task.CompletedTask;
         }
 
-        public virtual Task Move(int x, int y)
+        public virtual void Move(int x, int y)
         {
-            if (PositionX == x && PositionY == y) return Task.CompletedTask;
-            
+            if (PositionX == x && PositionY == y) return;
+
             PositionX = x;
             PositionY = y;
             PositionChanged = true;
-            return Task.CompletedTask;
         }
 
-        public virtual Task Goto(int x, int y)
+        public virtual void Goto(int x, int y)
         {
-            if (PositionX == x && PositionY == y) return Task.CompletedTask;
-            if (TargetPositionX == x && TargetPositionY == y) return Task.CompletedTask;
+            if (PositionX == x && PositionY == y) return;
+            if (TargetPositionX == x && TargetPositionY == y) return;
 
             var animation =
                 _animationManager.GetAnimation(EntityClass, AnimationType.Run, AnimationSubType.General);
@@ -160,8 +158,6 @@ namespace QuantumCore.Game.World.Entities
                 var duration = (int) ((distance / animationSpeed) * 1000) * i / 100;
                 MovementDuration = (uint) duration;
             }
-            
-            return Task.CompletedTask;
         }
 
         public virtual void Wait(int x, int y)
@@ -181,11 +177,11 @@ namespace QuantumCore.Game.World.Entities
         public abstract int GetMinDamage();
         public abstract int GetMaxDamage();
         public abstract int GetBonusDamage();
-        public abstract ValueTask AddPoint(EPoints point, int value);
-        public abstract ValueTask SetPoint(EPoints point, uint value);
+        public abstract void AddPoint(EPoints point, int value);
+        public abstract void SetPoint(EPoints point, uint value);
         public abstract uint GetPoint(EPoints point);
 
-        public async Task Attack(IEntity victim, byte type)
+        public async void Attack(IEntity victim, byte type)
         {
             if (type == 0)
             {
@@ -217,7 +213,7 @@ namespace QuantumCore.Game.World.Entities
         private async Task MeleeAttack(IEntity victim)
         {
             // todo verify victim is in range
-            
+
             var attackerRating = Math.Min(90, (GetPoint(EPoints.Dx) * 4 + GetPoint(EPoints.Level) * 2) / 6);
             var victimRating = Math.Min(90, (victim.GetPoint(EPoints.Dx) * 4 + victim.GetPoint(EPoints.Level) * 2) / 6);
             var attackRating = (attackerRating + 210.0) / 300.0 - (victimRating * 2 + 5) / (victimRating + 95) * 3.0 / 10.0;
@@ -226,31 +222,31 @@ namespace QuantumCore.Game.World.Entities
             var maxDamage = GetMaxDamage();
 
             var damage = CoreRandom.GenerateInt32(minDamage, maxDamage + 1) * 2;
-            await SendDebugDamage(victim, $"{this}->{victim} Base Attack value: {damage}");
+            SendDebugDamage(victim, $"{this}->{victim} Base Attack value: {damage}");
             var attack = (int)(GetPoint(EPoints.AttackGrade) + damage - GetPoint(EPoints.Level) * 2);
             attack = (int) Math.Floor(attack * attackRating);
             attack += (int)GetPoint(EPoints.Level) * 2 + GetBonusDamage() * 2;
             attack *= (int)((100 + GetPoint(EPoints.AttackBonus) + GetPoint(EPoints.MagicAttackBonus)) / 100);
             attack = CalculateAttackBonus(victim, attack);
-            await SendDebugDamage(victim, $"{this}->{victim} With bonus and level {attack}");
+            SendDebugDamage(victim, $"{this}->{victim} With bonus and level {attack}");
 
             var defence = (int)(victim.GetPoint(EPoints.DefenceGrade) * (100 + victim.GetPoint(EPoints.DefenceBonus)) / 100);
-            await SendDebugDamage(victim, $"{this}->{victim} Base defence: {defence}");
+            SendDebugDamage(victim, $"{this}->{victim} Base defence: {defence}");
             if (this is MonsterEntity thisMonster)
             {
                 attack = (int) Math.Floor(attack * thisMonster.Proto.DamageMultiply);
             }
 
             damage = Math.Max(0, attack - defence);
-            await SendDebugDamage(victim, $"{this}->{victim} Melee damage: {damage}");
+            SendDebugDamage(victim, $"{this}->{victim} Melee damage: {damage}");
             if (damage < 3)
             {
                 damage = CoreRandom.GenerateInt32(1, 6);
             }
-            
+
             // todo reduce damage by weapon type resist
-            
-            await victim.Damage(this, EDamageType.Normal, damage);
+
+            victim.Damage(this, EDamageType.Normal, damage);
         }
 
         /// <summary>
@@ -265,7 +261,7 @@ namespace QuantumCore.Game.World.Entities
             // todo implement bonus attack against warriors etc...
             // todo implement resist again warriors etc...
             // todo implement resist against fire etc...
-            
+
             return attack;
         }
 
@@ -279,19 +275,19 @@ namespace QuantumCore.Game.World.Entities
             return (int)(baseExp * percentage);
         }
 
-        private async Task SendDebugDamage(IEntity other, string text)
+        private void SendDebugDamage(IEntity other, string text)
         {
             if (this is PlayerEntity thisPlayer)
             {
-                await thisPlayer.SendChatInfo(text);
+                thisPlayer.SendChatInfo(text);
             }
             if (other is PlayerEntity otherPlayer)
             {
-                await otherPlayer.SendChatInfo(text);
+                otherPlayer.SendChatInfo(text);
             }
         }
 
-        public async virtual Task<int> Damage(IEntity attacker, EDamageType damageType, int damage)
+        public virtual int Damage(IEntity attacker, EDamageType damageType, int damage)
         {
             if (damageType != EDamageType.Normal)
             {
@@ -301,8 +297,8 @@ namespace QuantumCore.Game.World.Entities
             // todo block
             // todo handle berserk, fear, blessing skill
             // todo handle reflect melee
-            
-            await SendDebugDamage(attacker, $"{attacker}->{this} Base Damage: {damage}");
+
+            SendDebugDamage(attacker, $"{attacker}->{this} Base Damage: {damage}");
 
             var isCritical = false;
             var isPenetrate = false;
@@ -317,7 +313,7 @@ namespace QuantumCore.Game.World.Entities
                     isCritical = true;
                     damage *= 2;
                     // todo send effect to clients
-                    await SendDebugDamage(attacker, $"{attacker}->{this} Critical hit -> {damage} (percentage was {criticalPercentage})");
+                    SendDebugDamage(attacker, $"{attacker}->{this} Critical hit -> {damage} (percentage was {criticalPercentage})");
                 }
             }
 
@@ -331,10 +327,10 @@ namespace QuantumCore.Game.World.Entities
                 {
                     isPenetrate = true;
                     damage += (int) (GetPoint(EPoints.DefenceGrade) * (100 + GetPoint(EPoints.DefenceBonus)) / 100);
-                    await SendDebugDamage(attacker, $"{attacker}->{this} Penetrate hit -> {damage} (percentage was {penetratePercentage})");
+                    SendDebugDamage(attacker, $"{attacker}->{this} Penetrate hit -> {damage} (percentage was {penetratePercentage})");
                 }
-            } 
-            
+            }
+
             // todo calculate hp steal, sp steal, hp recovery, sp recovery and mana burn
 
             byte damageFlags = 1; // 1 = normal
@@ -358,65 +354,64 @@ namespace QuantumCore.Game.World.Entities
 
                 if (victimPlayer != null)
                 {
-                    await victimPlayer.Connection.Send(damageInfo);
+                    victimPlayer.Connection.Send(damageInfo);
                 }
 
                 if (attackerPlayer != null)
                 {
-                    await attackerPlayer.Connection.Send(damageInfo);
+                    attackerPlayer.Connection.Send(damageInfo);
                 }
             }
 
             this.Health -= damage;
             if (victimPlayer != null)
             {
-                await victimPlayer.SendPoints();
+                victimPlayer.SendPoints();
             }
 
             foreach (var playerEntity in TargetedBy)
             {
-                await playerEntity.SendTarget();
+                playerEntity.SendTarget();
             }
 
             if (Health <= 0)
             {
-                await Die();
+                Die();
                 if (Type != EEntityType.Player && attackerPlayer is not null)
                 {
                     var exp = CalculateExperience(attackerPlayer.GetPoint(EPoints.Level));
-                    await attackerPlayer.AddPoint(EPoints.Experience, exp);
-                    await attackerPlayer.SendPoints();
+                    attackerPlayer.AddPoint(EPoints.Experience, exp);
+                    attackerPlayer.SendPoints();
                 }
             }
 
             return damage;
         }
 
-        public virtual ValueTask Die()
+        public virtual void Die()
         {
             Dead = true;
-            return ValueTask.CompletedTask;
         }
 
-        public async ValueTask AddNearbyEntity(IEntity entity)
+        public void AddNearbyEntity(IEntity entity)
         {
-            NearbyEntities.Add(entity);
-            await OnNewNearbyEntity(entity);
+            _nearbyEntities.Add(entity);
+            OnNewNearbyEntity(entity);
         }
 
-        public async ValueTask RemoveNearbyEntity(IEntity entity)
+        public void RemoveNearbyEntity(IEntity entity)
         {
-            if (NearbyEntities.Remove(entity))
+            if (_nearbyEntities.Remove(entity))
             {
-                await OnRemoveNearbyEntity(entity);
+                OnRemoveNearbyEntity(entity);
             }
         }
 
-        public async Task ForEachNearbyEntity(Func<IEntity, Task> action)
+        public void ForEachNearbyEntity(Action<IEntity> action)
         {
-            foreach (var entity in NearbyEntities)
+            foreach (var entity in _nearbyEntities)
             {
-                await action(entity);
+                action(entity);
             }
         }
     }

--- a/Executables/Game/World/Entities/GroundItem.cs
+++ b/Executables/Game/World/Entities/GroundItem.cs
@@ -32,15 +32,13 @@ public class GroundItem : Entity, IGroundItem
     public override EEntityType Type { get; }
 
     public override byte HealthPercentage { get; } = 0;
-    
-    protected override ValueTask OnNewNearbyEntity(IEntity entity)
+
+    protected override void OnNewNearbyEntity(IEntity entity)
     {
-       return ValueTask.CompletedTask;
     }
 
-    protected override ValueTask OnRemoveNearbyEntity(IEntity entity)
+    protected override void OnRemoveNearbyEntity(IEntity entity)
     {
-        return ValueTask.CompletedTask;
     }
 
     public override ValueTask OnDespawn()
@@ -48,9 +46,9 @@ public class GroundItem : Entity, IGroundItem
         return ValueTask.CompletedTask;
     }
 
-    public async override Task ShowEntity(IConnection connection)
+    public override void ShowEntity(IConnection connection)
     {
-        await connection.Send(new GroundItemAdd {
+        connection.Send(new GroundItemAdd {
             PositionX = PositionX,
             PositionY = PositionY,
             Vid = Vid,
@@ -58,9 +56,9 @@ public class GroundItem : Entity, IGroundItem
         });
     }
 
-    public async override Task HideEntity(IConnection connection)
+    public override void HideEntity(IConnection connection)
     {
-        await connection.Send(new GroundItemRemove {
+        connection.Send(new GroundItemRemove {
             Vid = Vid
         });
     }
@@ -90,13 +88,11 @@ public class GroundItem : Entity, IGroundItem
         throw new System.NotImplementedException();
     }
 
-    public override ValueTask AddPoint(EPoints point, int value)
+    public override void AddPoint(EPoints point, int value)
     {
-        throw new System.NotImplementedException();
     }
 
-    public override ValueTask SetPoint(EPoints point, uint value)
+    public override void SetPoint(EPoints point, uint value)
     {
-        throw new System.NotImplementedException();
     }
 }

--- a/Executables/Game/World/Entities/GroundItem.cs
+++ b/Executables/Game/World/Entities/GroundItem.cs
@@ -41,9 +41,8 @@ public class GroundItem : Entity, IGroundItem
     {
     }
 
-    public override ValueTask OnDespawn()
+    public override void OnDespawn()
     {
-        return ValueTask.CompletedTask;
     }
 
     public override void ShowEntity(IConnection connection)

--- a/Executables/Game/World/Entities/MonsterEntity.cs
+++ b/Executables/Game/World/Entities/MonsterEntity.cs
@@ -209,7 +209,7 @@ namespace QuantumCore.Game.World.Entities
         {
         }
 
-        public override ValueTask OnDespawn()
+        public override void OnDespawn()
         {
             if (Group != null)
             {
@@ -219,8 +219,6 @@ namespace QuantumCore.Game.World.Entities
                     (Map as Map)?.EnqueueGroupRespawn(Group);
                 }
             }
-
-            return ValueTask.CompletedTask;
         }
 
         public override void ShowEntity(IConnection connection)

--- a/Executables/Game/World/Entities/MonsterEntity.cs
+++ b/Executables/Game/World/Entities/MonsterEntity.cs
@@ -30,15 +30,15 @@ namespace QuantumCore.Game.World.Entities
         }
 
         public MonsterData Proto { get { return _proto; } }
-        
+
         public MonsterGroup Group { get; set; }
-        
+
         private readonly MonsterData _proto;
         private IBehaviour _behaviour;
         private bool _behaviourInitialized;
         private double _deadTime = 5000;
-        
-        public MonsterEntity(IMonsterManager monsterManager, IAnimationManager animationManager, IWorld world, ILogger logger, uint id, int x, int y, float rotation = 0) 
+
+        public MonsterEntity(IMonsterManager monsterManager, IAnimationManager animationManager, IWorld world, ILogger logger, uint id, int x, int y, float rotation = 0)
             : base(animationManager, world.GenerateVid())
         {
             _logger = logger;
@@ -48,7 +48,7 @@ namespace QuantumCore.Game.World.Entities
             Rotation = rotation;
 
             MovementSpeed = (byte) _proto.MoveSpeed;
-            
+
             Health = _proto.Hp;
             EntityClass = id;
 
@@ -63,17 +63,17 @@ namespace QuantumCore.Game.World.Entities
             }
         }
 
-        public async override Task Update(double elapsedTime)
+        public override void Update(double elapsedTime)
         {
             if (Dead)
             {
                 _deadTime -= elapsedTime;
                 if (_deadTime <= 0)
                 {
-                    await Map.DespawnEntity(this);
+                    Map.DespawnEntity(this);
                 }
             }
-            
+
             if (!_behaviourInitialized)
             {
                 _behaviour?.Init(this);
@@ -85,15 +85,15 @@ namespace QuantumCore.Game.World.Entities
                 _behaviour?.Update(elapsedTime);
             }
 
-            await base.Update(elapsedTime);
+            base.Update(elapsedTime);
         }
 
-        public override async Task Goto(int x, int y)
+        public override void Goto(int x, int y)
         {
             Rotation = (float) MathUtils.Rotation(x - PositionX, y - PositionY);
-            
-            await base.Goto(x, y);
-            
+
+            base.Goto(x, y);
+
             // Send movement to nearby players
             var movement = new CharacterMoveOut {
                 Vid = Vid,
@@ -104,13 +104,14 @@ namespace QuantumCore.Game.World.Entities
                 Time = (uint) GameServer.Instance.ServerTime,
                 Duration = MovementDuration
             };
-            await ForEachNearbyEntity(async entity =>
+
+            foreach (var entity in NearbyEntities)
             {
                 if (entity is PlayerEntity player)
                 {
-                    await player.Connection.Send(movement);
+                    player.Connection.Send(movement);
                 }
-            });
+            }
         }
 
         public override byte GetBattleType()
@@ -133,9 +134,9 @@ namespace QuantumCore.Game.World.Entities
             return 0; // monster don't have bonus damage as players have from their weapon
         }
 
-        public async override Task<int> Damage(IEntity attacker, EDamageType damageType, int damage)
+        public override int Damage(IEntity attacker, EDamageType damageType, int damage)
         {
-            damage = await base.Damage(attacker, damageType, damage);
+            damage = base.Damage(attacker, damageType, damage);
 
             if (damage >= 0)
             {
@@ -151,14 +152,12 @@ namespace QuantumCore.Game.World.Entities
             Behaviour?.TookDamage(attacker, 0);
         }
 
-        public override ValueTask AddPoint(EPoints point, int value)
+        public override void AddPoint(EPoints point, int value)
         {
-            return ValueTask.CompletedTask;
         }
 
-        public override ValueTask SetPoint(EPoints point, uint value)
+        public override void SetPoint(EPoints point, uint value)
         {
-            return ValueTask.CompletedTask;
         }
 
         public override uint GetPoint(EPoints point)
@@ -182,35 +181,32 @@ namespace QuantumCore.Game.World.Entities
             return 0;
         }
 
-        public override async ValueTask Die()
+        public override void Die()
         {
             if (Dead)
             {
                 return;
             }
-            
-            await base.Die();
+
+            base.Die();
 
             var dead = new CharacterDead { Vid = Vid };
-            await ForEachNearbyEntity(async entity =>
+            foreach (var entity in NearbyEntities)
             {
                 if (entity is PlayerEntity player)
                 {
-                    await player.Connection.Send(dead);
+                    player.Connection.Send(dead);
                 }
-            });
+            }
         }
 
-        protected override ValueTask OnNewNearbyEntity(IEntity entity)
+        protected override void OnNewNearbyEntity(IEntity entity)
         {
             _behaviour?.OnNewNearbyEntity(entity);
-        
-            return ValueTask.CompletedTask;
         }
 
-        protected override ValueTask OnRemoveNearbyEntity(IEntity entity)
+        protected override void OnRemoveNearbyEntity(IEntity entity)
         {
-            return ValueTask.CompletedTask;
         }
 
         public override ValueTask OnDespawn()
@@ -223,18 +219,18 @@ namespace QuantumCore.Game.World.Entities
                     (Map as Map)?.EnqueueGroupRespawn(Group);
                 }
             }
-        
+
             return ValueTask.CompletedTask;
         }
 
-        public override async Task ShowEntity(IConnection connection)
+        public override void ShowEntity(IConnection connection)
         {
             if (Dead)
             {
                 return; // no need to send dead entities to new players
             }
-            
-            await connection.Send(new SpawnCharacter
+
+            connection.Send(new SpawnCharacter
             {
                 Vid = Vid,
                 CharacterType = _proto.Type,
@@ -249,7 +245,7 @@ namespace QuantumCore.Game.World.Entities
             if (_proto.Type == (byte) EEntityType.Npc)
             {
                 // NPCs need additional information too to show up for some reason
-                await connection.Send(new CharacterInfo {
+                connection.Send(new CharacterInfo {
                     Vid = Vid,
                     Empire = _proto.Empire,
                     Level = _proto.Level,
@@ -257,10 +253,10 @@ namespace QuantumCore.Game.World.Entities
                 });
             }
         }
-        
-        public async override Task HideEntity(IConnection connection)
+
+        public override void HideEntity(IConnection connection)
         {
-            await connection.Send(new RemoveCharacter
+            connection.Send(new RemoveCharacter
             {
                 Vid = Vid
             });
@@ -268,7 +264,7 @@ namespace QuantumCore.Game.World.Entities
 
         public override string ToString()
         {
-            return $"{_proto.TranslatedName.Trim((char) 0x00)} ({_proto.Id})";
+            return $"{_proto.TranslatedName?.Trim((char) 0x00)} ({_proto.Id})";
         }
     }
 }

--- a/Executables/Game/World/Entities/PlayerEntity.cs
+++ b/Executables/Game/World/Entities/PlayerEntity.cs
@@ -238,25 +238,11 @@ namespace QuantumCore.Game.World.Entities
                 return;
             }
 
-            _world.DespawnEntity(this);
-
             PositionX = x;
             PositionY = y;
 
             // Reset movement info
             Stop();
-
-            _world.SpawnEntity(this);
-
-            Show(Connection);
-
-            foreach (var entity in NearbyEntities)
-            {
-                if (entity is PlayerEntity p)
-                {
-                    p.Show(Connection);
-                }
-            }
         }
 
         private void CalculateDefence()
@@ -608,8 +594,8 @@ namespace QuantumCore.Game.World.Entities
                     if (args.ItemInstance is not null)
                     {
                         var item = _itemManager.GetItem(args.ItemInstance.ItemId);
-                        Player.MinWeaponDamage = (uint)(item.GetMinWeaponDamage() + item.Values[5]);
-                        Player.MinWeaponDamage = (uint)(item.GetMaxWeaponDamage() + item.Values[5]);
+                        Player.MinWeaponDamage = item.GetMinWeaponDamage();
+                        Player.MaxWeaponDamage = item.GetMaxWeaponDamage();
                     }
                     else
                     {
@@ -893,7 +879,7 @@ namespace QuantumCore.Game.World.Entities
                         // Equipment
                         if (Inventory.EquipmentWindow.GetItem(position) == null)
                         {
-                            Inventory.EquipmentWindow.SetItem(item, position);
+                            Inventory.SetEquipment(item, position);
                             item.Set(_cacheManager, Player.Id, window, position).Wait(); // TODO
                             CalculateDefence();
                             SendCharacterUpdate();
@@ -1091,6 +1077,7 @@ namespace QuantumCore.Game.World.Entities
 
         public void Disconnect()
         {
+            Inventory.OnSlotChanged -= Inventory_OnSlotChanged;
             Connection.Close();
         }
 

--- a/Executables/Game/World/Entities/PlayerEntity.cs
+++ b/Executables/Game/World/Entities/PlayerEntity.cs
@@ -78,7 +78,7 @@ namespace QuantumCore.Game.World.Entities
                 }
             }
         }
-        
+
         private byte _attackSpeed = 140;
         private uint _defence;
 
@@ -99,7 +99,7 @@ namespace QuantumCore.Game.World.Entities
 
         public PlayerEntity(Player player, IGameConnection connection, IItemManager itemManager, IJobManager jobManager,
             IExperienceManager experienceManager, IAnimationManager animationManager, IDbConnection db,
-            IQuestManager questManager, ICacheManager cacheManager, IWorld world, ILogger<PlayerEntity> logger) 
+            IQuestManager questManager, ICacheManager cacheManager, IWorld world, ILogger<PlayerEntity> logger)
             : base(animationManager, world.GenerateVid())
         {
             Connection = connection;
@@ -152,12 +152,12 @@ namespace QuantumCore.Game.World.Entities
                 "SELECT Empire FROM account.accounts WHERE Id = @AccountId", new {AccountId = Player.AccountId});
             await Inventory.Load();
             await QuickSlotBar.Load();
-            Health = (int) GetPoint(EPoints.MaxHp); // todo: cache hp of player 
+            Health = (int) GetPoint(EPoints.MaxHp); // todo: cache hp of player
             Mana = (int) GetPoint(EPoints.MaxSp);
             await LoadPermGroups();
-            
+
             _questManager.InitializePlayer(this);
-            
+
             CalculateDefence();
         }
 
@@ -185,16 +185,16 @@ namespace QuantumCore.Game.World.Entities
             return (T) Quests[id];
         }
 
-        private async Task Warp(int x, int y)
+        private void Warp(int x, int y)
         {
-            await _world.DespawnEntity(this);
-            
+            _world.DespawnEntity(this);
+
             PositionX = x;
             PositionY = y;
-            
+
             var host = _world.GetMapHost(PositionX, PositionY);
 
-            await Persist();
+            Persist().Wait(); // TODO
             _logger.LogInformation("Warp!");
             var packet = new Warp {
                 PositionX = PositionX,
@@ -202,20 +202,20 @@ namespace QuantumCore.Game.World.Entities
                 ServerAddress = IpUtils.ConvertIpToUInt(host.Ip),
                 ServerPort = host.Port
             };
-            await Connection.Send(packet);
+            Connection.Send(packet);
         }
 
-        public override async Task Move(int x, int y)
+        public override void Move(int x, int y)
         {
             if (PositionX == x && PositionY == y) return;
-            
+
             if (!Map.IsPositionInside(x, y))
             {
-                await Warp(x, y);
+                Warp(x, y);
                 return;
             }
 
-            await _world.DespawnEntity(this);
+            _world.DespawnEntity(this);
 
             PositionX = x;
             PositionY = y;
@@ -224,27 +224,27 @@ namespace QuantumCore.Game.World.Entities
             Stop();
 
             // Spawn the player
-            if (!await _world.SpawnEntity(this))
+            if (!_world.SpawnEntity(this))
             {
                 _logger.LogWarning("Failed to spawn player entity");
                 Connection.Close();
             }
 
-            await Show(Connection);
+            Show(Connection);
 
-            await ForEachNearbyEntity(async entity =>
+            foreach (var entity in NearbyEntities)
             {
                 if (entity is PlayerEntity p)
                 {
-                    await p.Show(Connection);
+                    p.Show(Connection);
                 }
-            });
+            }
         }
 
         private void CalculateDefence()
         {
             _defence = GetPoint(EPoints.Level) + (uint)Math.Floor(0.8 * GetPoint(EPoints.Ht));
-            
+
             foreach (var slot in Enum.GetValues<EquipmentSlots>())
             {
                 var item = Inventory.EquipmentWindow.GetItem(slot);
@@ -254,33 +254,33 @@ namespace QuantumCore.Game.World.Entities
 
                 _defence += (uint)proto.Values[1] + (uint)proto.Values[5] * 2;
             }
-            
+
             _logger.LogDebug("Calculate defence value for {Name}, result: {Defence}", Name, _defence);
-            
+
             // todo add defence bonus from quests
         }
 
-        public override async ValueTask Die()
+        public override void Die()
         {
             if (Dead)
             {
                 return;
             }
-            
-            await base.Die();
+
+            base.Die();
 
             var dead = new CharacterDead { Vid = Vid };
-            await ForEachNearbyEntity(async entity =>
+            foreach (var entity in NearbyEntities)
             {
                 if (entity is PlayerEntity player)
                 {
-                    await player.Connection.Send(dead);
+                    player.Connection.Send(dead);
                 }
-            });
-            await Connection.Send(dead);
+            }
+            Connection.Send(dead);
         }
 
-        public async Task Respawn(bool town)
+        public void Respawn(bool town)
         {
             if (!Dead)
             {
@@ -290,31 +290,31 @@ namespace QuantumCore.Game.World.Entities
             Shop?.Close(this);
 
             Dead = false;
-            
+
             // todo implement respawn in town
             // todo spawn with invisible affect
-            
-            await SendChatCommand("CloseRestartWindow");
-            await Connection.SetPhaseAsync(EPhases.Game);
+
+            SendChatCommand("CloseRestartWindow");
+            Connection.SetPhaseAsync(EPhases.Game);
 
             var remove = new RemoveCharacter { Vid = Vid };
-            
-            await Connection.Send(remove);
-            await Show(Connection);
-            
-            await ForEachNearbyEntity(async entity =>
+
+            Connection.Send(remove);
+            Show(Connection);
+
+            foreach (var entity in NearbyEntities)
             {
                 if (entity is PlayerEntity pe)
                 {
-                    await ShowEntity(pe.Connection);
+                    ShowEntity(pe.Connection);
                 }
-                
-                await entity.ShowEntity(Connection);
-            });
+
+                entity.ShowEntity(Connection);
+            }
 
             Health = 50;
             Mana = 50;
-            await SendPoints();
+            SendPoints();
         }
 
         private void GiveStatusPoints()
@@ -322,7 +322,7 @@ namespace QuantumCore.Game.World.Entities
             var shouldHavePoints = (uint) ((Player.Level - 1) * 3);
             var steps = (byte) Math.Floor(GetPoint(EPoints.Experience) / (double)GetPoint(EPoints.NeededExperience) * 4);
             shouldHavePoints += steps;
-            
+
             if (shouldHavePoints <= Player.GivenStatusPoints)
             {
                 // Remove available points if possible
@@ -337,31 +337,31 @@ namespace QuantumCore.Game.World.Entities
 
                 return;
             }
-            
+
             Player.AvailableStatusPoints += shouldHavePoints - Player.GivenStatusPoints;
             Player.GivenStatusPoints = shouldHavePoints;
         }
 
-        private async ValueTask<bool> CheckLevelUp()
+        private bool CheckLevelUp()
         {
             var exp = GetPoint(EPoints.Experience);
             var needed = GetPoint(EPoints.NeededExperience);
-            
+
             if (exp >= needed)
             {
                 // todo level up animation
-                
-                await AddPoint(EPoints.Level, 1);
-                await SetPoint(EPoints.Experience, exp - needed);
 
-                if (!await CheckLevelUp())
+                AddPoint(EPoints.Level, 1);
+                SetPoint(EPoints.Experience, exp - needed);
+
+                if (!CheckLevelUp())
                 {
-                    await SendPoints();
+                    SendPoints();
                 }
 
                 return true;
             }
-            
+
             GiveStatusPoints();
             return false;
         }
@@ -383,12 +383,12 @@ namespace QuantumCore.Game.World.Entities
             var b = (GetPoint(EPoints.Dx) * 4 + GetPoint(EPoints.Level) * 2) / 6;
             return 100 * ((b > 90 ? 90 : b) + 210) / 300;
         }
-        
-        public async override Task Update(double elapsedTime)
+
+        public override void Update(double elapsedTime)
         {
             if (Map == null) return; // We don't have a map yet so we aren't spawned
 
-            await base.Update(elapsedTime);
+            base.Update(elapsedTime);
 
             var maxHp = GetPoint(EPoints.MaxHp);
             if (Health < maxHp)
@@ -398,7 +398,7 @@ namespace QuantumCore.Game.World.Entities
                 {
                     var factor = State == EEntityState.Idle ? 0.05 : 0.01;
                     Health = Math.Min((int) maxHp, Health + 15 + (int) (maxHp * factor));
-                    await SendPoints();
+                    SendPoints();
 
                     _healthRegenTime += HealthRegenInterval;
                 }
@@ -411,7 +411,7 @@ namespace QuantumCore.Game.World.Entities
                 {
                     var factor = State == EEntityState.Idle ? 0.05 : 0.01;
                     Mana = Math.Min((int) maxSp, Mana + 15 + (int) (maxSp * factor));
-                    await SendPoints();
+                    SendPoints();
 
                     _manaRegenTime += ManaRegenInterval;
                 }
@@ -420,7 +420,7 @@ namespace QuantumCore.Game.World.Entities
             _persistTime += (int)elapsedTime;
             if (_persistTime > PersistInterval)
             {
-                await Persist();
+                Persist().Wait(); // TODO
                 _persistTime -= PersistInterval;
             }
         }
@@ -457,24 +457,24 @@ namespace QuantumCore.Game.World.Entities
             return item.Values[5];
         }
 
-        public override async ValueTask AddPoint(EPoints point, int value)
+        public override void AddPoint(EPoints point, int value)
         {
             if (value == 0)
             {
                 return;
             }
-            
+
             switch (point)
             {
                 case EPoints.Level:
                     Player.Level = (byte)(Player.Level + value);
-                    await ForEachNearbyEntity(async entity =>
+                    foreach (var entity in NearbyEntities)
                     {
                         if (entity is IPlayerEntity other)
                         {
-                            await SendCharacterAdditional(other.Connection);
+                            SendCharacterAdditional(other.Connection);
                         }
-                    });
+                    }
                     GiveStatusPoints();
                     break;
                 case EPoints.Experience:
@@ -494,9 +494,9 @@ namespace QuantumCore.Game.World.Entities
 
                     if (value > 0)
                     {
-                        await CheckLevelUp();
+                        CheckLevelUp();
                     }
-                    
+
                     break;
                 case EPoints.Gold:
                     var gold = Player.Gold + value;
@@ -554,24 +554,24 @@ namespace QuantumCore.Game.World.Entities
             }
         }
 
-        public override async ValueTask SetPoint(EPoints point, uint value)
+        public override void SetPoint(EPoints point, uint value)
         {
             switch (point)
             {
                 case EPoints.Level:
                     Player.Level = (byte) value;
-                    await ForEachNearbyEntity(async entity =>
+                    foreach (var entity in NearbyEntities)
                     {
                         if (entity is IPlayerEntity other)
                         {
-                            await SendCharacterAdditional(other.Connection);
+                            SendCharacterAdditional(other.Connection);
                         }
-                    });
+                    }
                     GiveStatusPoints();
                     break;
                 case EPoints.Experience:
                     Player.Experience = value;
-                    await CheckLevelUp();
+                    CheckLevelUp();
                     break;
                 case EPoints.Gold:
                     Player.Gold = value;
@@ -669,24 +669,24 @@ namespace QuantumCore.Game.World.Entities
         private async Task Persist()
         {
             await QuickSlotBar.Persist();
-            
+
             Player.PositionX = PositionX;
             Player.PositionY = PositionY;
-            
+
             await _cacheManager.Set($"player:{Player.Id}", Player);
         }
 
-        protected override async ValueTask OnNewNearbyEntity(IEntity entity)
+        protected override void OnNewNearbyEntity(IEntity entity)
         {
-            await entity.ShowEntity(Connection);
+            entity.ShowEntity(Connection);
         }
 
-        protected override async ValueTask OnRemoveNearbyEntity(IEntity entity)
+        protected override void OnRemoveNearbyEntity(IEntity entity)
         {
-            await entity.HideEntity(Connection);
+            entity.HideEntity(Connection);
         }
 
-        public async Task DropItem(ItemInstance item, byte count)
+        public void DropItem(ItemInstance item, byte count)
         {
             if (count > item.Count)
             {
@@ -695,16 +695,16 @@ namespace QuantumCore.Game.World.Entities
 
             if (item.Count == count)
             {
-                await RemoveItem(item);
-                await SendRemoveItem(item.Window, (ushort) item.Position);
-                await item.Set(_cacheManager, Guid.Empty, 0, 0);
+                RemoveItem(item);
+                SendRemoveItem(item.Window, (ushort) item.Position);
+                item.Set(_cacheManager, Guid.Empty, 0, 0).Wait(); // TODO
             }
             else
             {
                 item.Count -= count;
-                await item.Persist(_cacheManager);
-                
-                await SendItem(item);
+                item.Persist(_cacheManager).Wait(); // TODO
+
+                SendItem(item);
 
                 item = _itemManager.CreateItem(_itemManager.GetItem(item.ItemId), count);
             }
@@ -712,39 +712,39 @@ namespace QuantumCore.Game.World.Entities
             (Map as Map)?.AddGroundItem(item, PositionX, PositionY);
         }
 
-        public async Task Pickup(IGroundItem groundItem)
+        public void Pickup(IGroundItem groundItem)
         {
             var item = groundItem.Item;
             if (item.ItemId == 1)
             {
-                await AddPoint(EPoints.Gold, (int) groundItem.Amount);
-                await SendPoints();
-                await Map.DespawnEntity(groundItem);
+                AddPoint(EPoints.Gold, (int) groundItem.Amount);
+                SendPoints();
+                Map.DespawnEntity(groundItem);
 
                 return;
             }
 
-            if (!await Inventory.PlaceItem(item))
+            if (!Inventory.PlaceItem(item).Result) // TODO
             {
-                await SendChatInfo("No inventory space left");
+                SendChatInfo("No inventory space left");
                 return;
             }
-            
-            await SendItem(item);
-            await Map.DespawnEntity(groundItem);
+
+            SendItem(item);
+            Map.DespawnEntity(groundItem);
         }
 
-        public async Task DropGold(uint amount)
+        public void DropGold(uint amount)
         {
             // todo prevent crashing the server with dropping gold too often ;)
-            
+
             if (amount > GetPoint(EPoints.Gold))
             {
                 return; // We can't drop more gold than we have ^^
             }
-            
-            await AddPoint(EPoints.Gold, -(int)amount);
-            await SendPoints();
+
+            AddPoint(EPoints.Gold, -(int)amount);
+            SendPoints();
 
             var item = _itemManager.CreateItem(_itemManager.GetItem(1), 1); // count will be overwritten as it's gold
             (Map as Map)?.AddGroundItem(item, PositionX, PositionY, amount); // todo add method to IMap interface when we have an item interface...
@@ -788,7 +788,7 @@ namespace QuantumCore.Game.World.Entities
                         {
                             return Inventory.EquipmentWindow.GetItem(position) == null;
                         }
-                        
+
                         return false;
                     }
                     else
@@ -815,7 +815,7 @@ namespace QuantumCore.Game.World.Entities
                 // No wear flags -> not wearable
                 return false;
             }
-            
+
             // Check anti flags
             var antiFlags = (EAntiFlags) proto.AntiFlags;
             if (antiFlags.HasFlag(AntiFlagClass))
@@ -839,23 +839,23 @@ namespace QuantumCore.Game.World.Entities
                     }
                 }
             }
-            
+
             return true;
         }
 
-        public async Task<bool> DestroyItem(ItemInstance item)
+        public bool DestroyItem(ItemInstance item)
         {
-            await RemoveItem(item);
-            if (!await item.Destroy(_cacheManager))
+            RemoveItem(item);
+            if (!item.Destroy(_cacheManager).Result) // TODO
             {
                 return false;
             }
 
-            await SendRemoveItem(item.Window, (ushort) item.Position);
+            SendRemoveItem(item.Window, (ushort) item.Position);
             return true;
         }
-        
-        public async Task RemoveItem(ItemInstance item)
+
+        public void RemoveItem(ItemInstance item)
         {
             switch (item.Window)
             {
@@ -865,8 +865,8 @@ namespace QuantumCore.Game.World.Entities
                         // Equipment
                         Inventory.EquipmentWindow.RemoveItem(item);
                         CalculateDefence();
-                        await SendCharacterUpdate();
-                        await SendPoints();
+                        SendCharacterUpdate();
+                        SendPoints();
                     }
                     else
                     {
@@ -878,7 +878,7 @@ namespace QuantumCore.Game.World.Entities
             }
         }
 
-        public async Task SetItem(ItemInstance item, byte window, ushort position)
+        public void SetItem(ItemInstance item, byte window, ushort position)
         {
             switch (window)
             {
@@ -889,36 +889,36 @@ namespace QuantumCore.Game.World.Entities
                         if (Inventory.EquipmentWindow.GetItem(position) == null)
                         {
                             Inventory.EquipmentWindow.SetItem(item, position);
-                            await item.Set(_cacheManager, Player.Id, window, position);
+                            item.Set(_cacheManager, Player.Id, window, position).Wait(); // TODO
                             CalculateDefence();
-                            await SendCharacterUpdate();
-                            await SendPoints();
+                            SendCharacterUpdate();
+                            SendPoints();
                         }
                     }
                     else
                     {
                         // Inventory
-                        await Inventory.PlaceItem(item, position);
-                    } 
+                        Inventory.PlaceItem(item, position);
+                    }
                     break;
             }
         }
 
-        public override async Task ShowEntity(IConnection connection)
+        public override void ShowEntity(IConnection connection)
         {
-            await SendCharacter(connection);
-            await SendCharacterAdditional(connection);
+            SendCharacter(connection);
+            SendCharacterAdditional(connection);
         }
 
-        public override async Task HideEntity(IConnection connection)
+        public override void HideEntity(IConnection connection)
         {
-            await connection.Send(new RemoveCharacter
+            connection.Send(new RemoveCharacter
             {
                 Vid = Vid
             });
         }
 
-        public async Task SendBasicData()
+        public void SendBasicData()
         {
             var details = new CharacterDetails
             {
@@ -929,45 +929,45 @@ namespace QuantumCore.Game.World.Entities
                 PositionY = PositionY,
                 Empire = Empire
             };
-            await Connection.Send(details);
+            Connection.Send(details);
         }
 
-        public async Task SendPoints()
+        public void SendPoints()
         {
             var points = new CharacterPoints();
             for (var i = 0; i < points.Points.Length; i++)
             {
                 points.Points[i] = GetPoint((EPoints) i);
             }
-            await Connection.Send(points);
+            Connection.Send(points);
         }
 
-        public async Task SendInventory()
+        public void SendInventory()
         {
             foreach (var item in Inventory.Items)
             {
-                await SendItem(item);
+                SendItem(item);
             }
 
-            await Inventory.EquipmentWindow.Send(this);
+            Inventory.EquipmentWindow.Send(this);
         }
 
-        public async Task SendItem(ItemInstance item)
+        public void SendItem(ItemInstance item)
         {
             Debug.Assert(item.PlayerId == Player.Id);
-            
+
             var p = new SetItem {
                 Window = item.Window,
                 Position = (ushort)item.Position,
                 ItemId = item.ItemId,
                 Count = item.Count
             };
-            await Connection.Send(p);
+            Connection.Send(p);
         }
 
-        public async Task SendRemoveItem(byte window, ushort position)
+        public void SendRemoveItem(byte window, ushort position)
         {
-            await Connection.Send(new SetItem {
+            Connection.Send(new SetItem {
                 Window = window,
                 Position = position,
                 ItemId = 0,
@@ -975,9 +975,9 @@ namespace QuantumCore.Game.World.Entities
             });
         }
 
-        public async Task SendCharacter(IConnection connection)
+        public void SendCharacter(IConnection connection)
         {
-            await connection.Send(new SpawnCharacter
+            connection.Send(new SpawnCharacter
             {
                 Vid = Vid,
                 CharacterType = (byte) EEntityType.Player,
@@ -990,24 +990,24 @@ namespace QuantumCore.Game.World.Entities
             });
         }
 
-        public async Task SendCharacterAdditional(IConnection connection)
+        public void SendCharacterAdditional(IConnection connection)
         {
-            await connection.Send(new CharacterInfo
+            connection.Send(new CharacterInfo
             {
                 Vid = Vid,
                 Name = Player.Name,
                 Empire = Empire,
                 Level = Player.Level,
                 Parts = new ushort[] {
-                    (ushort)(Inventory.EquipmentWindow.Body?.ItemId ?? 0), 
-                    (ushort)(Inventory.EquipmentWindow.Weapon?.ItemId ?? 0), 
-                    0, 
+                    (ushort)(Inventory.EquipmentWindow.Body?.ItemId ?? 0),
+                    (ushort)(Inventory.EquipmentWindow.Weapon?.ItemId ?? 0),
+                    0,
                     (ushort)(Inventory.EquipmentWindow.Hair?.ItemId ?? 0)
                 }
             });
         }
 
-        public async Task SendCharacterUpdate()
+        public void SendCharacterUpdate()
         {
             var packet = new CharacterUpdate {
                 Vid = Vid,
@@ -1019,19 +1019,19 @@ namespace QuantumCore.Game.World.Entities
                 MoveSpeed = MovementSpeed,
                 AttackSpeed = _attackSpeed
             };
-            
-            await Connection.Send(packet);
-            
-            await ForEachNearbyEntity(async entity =>
+
+            Connection.Send(packet);
+
+            foreach (var entity in NearbyEntities)
             {
                 if (entity is PlayerEntity p)
                 {
-                    await p.Connection.Send(packet);
+                    p.Connection.Send(packet);
                 }
-            });
+            }
         }
 
-        public async Task SendChatMessage(string message)
+        public void SendChatMessage(string message)
         {
             var chat = new ChatOutcoming
             {
@@ -1040,10 +1040,10 @@ namespace QuantumCore.Game.World.Entities
                 Empire = Empire,
                 Message = message
             };
-            await Connection.Send(chat);
+            Connection.Send(chat);
         }
-		
-        public async Task SendChatCommand(string message)
+
+        public void SendChatCommand(string message)
         {
             var chat = new ChatOutcoming
             {
@@ -1052,10 +1052,10 @@ namespace QuantumCore.Game.World.Entities
                 Empire = Empire,
                 Message = message
             };
-            await Connection.Send(chat);
+            Connection.Send(chat);
         }
-		
-        public async Task SendChatInfo(string message)
+
+        public void SendChatInfo(string message)
         {
             var chat = new ChatOutcoming
             {
@@ -1064,10 +1064,10 @@ namespace QuantumCore.Game.World.Entities
                 Empire = Empire,
                 Message = message
             };
-            await Connection.Send(chat);
+            Connection.Send(chat);
         }
 
-        public async Task SendTarget()
+        public void SendTarget()
         {
             var packet = new SetTarget();
             if (Target != null)
@@ -1075,13 +1075,13 @@ namespace QuantumCore.Game.World.Entities
                 packet.TargetVid = Target.Vid;
                 packet.Percentage = Target.HealthPercentage;
             }
-            await Connection.Send(packet);
+            Connection.Send(packet);
         }
-        
-        public async Task Show(IConnection connection)
+
+        public void Show(IConnection connection)
         {
-            await SendCharacter(connection);
-            await SendCharacterAdditional(connection);
+            SendCharacter(connection);
+            SendCharacterAdditional(connection);
         }
 
         public void Disconnect()

--- a/Executables/Game/World/Entities/PlayerEntity.cs
+++ b/Executables/Game/World/Entities/PlayerEntity.cs
@@ -246,12 +246,7 @@ namespace QuantumCore.Game.World.Entities
             // Reset movement info
             Stop();
 
-            // Spawn the player
-            if (!_world.SpawnEntity(this))
-            {
-                _logger.LogWarning("Failed to spawn player entity");
-                Connection.Close();
-            }
+            _world.SpawnEntity(this);
 
             Show(Connection);
 
@@ -760,9 +755,9 @@ namespace QuantumCore.Game.World.Entities
             (Map as Map)?.AddGroundItem(item, PositionX, PositionY, amount); // todo add method to IMap interface when we have an item interface...
         }
 
-        public async override ValueTask OnDespawn()
+        public override void OnDespawn()
         {
-            await Persist();
+            Persist().Wait(); // TODO
         }
 
         public ItemInstance GetItem(byte window, ushort position)

--- a/Executables/Game/World/Map.cs
+++ b/Executables/Game/World/Map.cs
@@ -100,8 +100,9 @@ namespace QuantumCore.Game.World
                 }
 
                 _quadTree.QueryAround(nearby, entity.PositionX, entity.PositionY, Entity.ViewDistance, filter);
-                foreach (var e in nearby.Where(e => e != entity))
+                foreach (var e in nearby)
                 {
+                    if (e == entity) continue;
                     entity.AddNearbyEntity(e);
                     e.AddNearbyEntity(entity);
                 }
@@ -128,7 +129,6 @@ namespace QuantumCore.Game.World
                 // Remove entity from the quad tree
                 _quadTree.Remove(entity);
             }
-            _pendingRemovals.Clear();
 
             foreach (var entity in _entities)
             {

--- a/Executables/Game/World/Map.cs
+++ b/Executables/Game/World/Map.cs
@@ -8,6 +8,7 @@ using QuantumCore.API.Game.World;
 using QuantumCore.Core.Cache;
 using QuantumCore.Core.Event;
 using QuantumCore.Core.Utils;
+using QuantumCore.Game.Services;
 using QuantumCore.Game.World.Entities;
 
 // using QuantumCore.Core.API;
@@ -37,10 +38,11 @@ namespace QuantumCore.Game.World
         private readonly ICacheManager _cacheManager;
         private readonly IWorld _world;
         private readonly ILogger _logger;
+        private readonly ISpawnPointProvider _spawnPointProvider;
         private readonly HostingOptions _options;
 
-        public Map(IMonsterManager monsterManager, IAnimationManager animationManager, ICacheManager cacheManager, 
-            IWorld world, IOptions<HostingOptions> options, ILogger logger,
+        public Map(IMonsterManager monsterManager, IAnimationManager animationManager, ICacheManager cacheManager,
+            IWorld world, IOptions<HostingOptions> options, ILogger logger, ISpawnPointProvider spawnPointProvider,
             string name, uint x, uint y, uint width, uint height)
         {
             _monsterManager = monsterManager;
@@ -48,6 +50,7 @@ namespace QuantumCore.Game.World
             _cacheManager = cacheManager;
             _world = world;
             _logger = logger;
+            _spawnPointProvider = spawnPointProvider;
             _options = options.Value;
             Name = name;
             PositionX = x;
@@ -64,17 +67,12 @@ namespace QuantumCore.Game.World
             await _cacheManager.Set($"maps:{Name}", $"{IpUtils.PublicIP}:{_options.Port}");
             await _cacheManager.Publish("maps", $"{Name} {IpUtils.PublicIP}:{_options.Port}");
 
-            var cfg = new ConfigurationBuilder()
-                .AddTomlFile(Path.Join("data", "maps", Name, "spawn.toml"), true)
-                .Build();
+            _spawnPoints.AddRange(await _spawnPointProvider.GetSpawnPointsForMap(Name));
 
-            _spawnPoints.AddRange(cfg.GetSection("spawn").Get<SpawnPoint[]>() ?? Array.Empty<SpawnPoint>());
-            
-            _logger.LogDebug("Loaded {SpawnPointsCount} spawn points", _spawnPoints.Count);
-            
-            
+            _logger.LogDebug("Loaded {SpawnPointsCount} spawn points for map {MapName}", _spawnPoints.Count, Name);
+
             // Populate map
-            foreach(var spawnPoint in _spawnPoints) 
+            foreach(var spawnPoint in _spawnPoints)
             {
                 var monsterGroup = new MonsterGroup { SpawnPoint = spawnPoint };
                 await SpawnGroup(monsterGroup);
@@ -90,15 +88,15 @@ namespace QuantumCore.Game.World
                 _entities.Remove(entity as Entity);
             }
             _pendingRemovals.Clear();
-            
-            foreach (var entity in _entities)
+
+            foreach (var entity in _entities.ToArray())
             {
                 await entity.Update(elapsedTime);
 
                 if (entity.PositionChanged)
                 {
                     entity.PositionChanged = false;
-                    
+
                     // Update position in our quad tree (used for faster nearby look up)
                     _quadTree.UpdatePosition(entity);
 
@@ -161,51 +159,43 @@ namespace QuantumCore.Game.World
             var spawnPoint = groupInstance.SpawnPoint;
             switch (spawnPoint.Type)
             {
+                case ESpawnPointType.GroupCollection:
+                    var groupCollection = _world.GetGroupCollection(spawnPoint.Monster);
+                    if (groupCollection != null)
+                    {
+                        foreach (var member in groupCollection.Members)
+                        {
+                            var group = _world.GetGroup(member.Id);
+                            if (group != null)
+                            {
+                                for (int i = 0; i < member.Amount; i++)
+                                {
+                                    await SpawnGroup(groupInstance, spawnPoint, group);
+                                }
+                            }
+                        }
+                    }
+                    break;
                 case ESpawnPointType.Group:
                 {
-                    var group = _world.GetGroup(CoreRandom.GetRandom(spawnPoint.Groups));
+                    var group = _world.GetGroup(spawnPoint.Monster);
                     if (group != null)
                     {
-                        var baseX = spawnPoint.X + RandomNumberGenerator.GetInt32(-spawnPoint.Range, spawnPoint.Range);
-                        var baseY = spawnPoint.Y + RandomNumberGenerator.GetInt32(-spawnPoint.Range, spawnPoint.Range);
-
-                        spawnPoint.CurrentGroup = groupInstance;
-
-                        foreach (var member in group.Members)
-                        {
-                            var monster = new MonsterEntity(_monsterManager, _animationManager, _world, _logger, member.Id,
-                                (int) (PositionX + (baseX + RandomNumberGenerator.GetInt32(-5, 5)) * 100),
-                                (int) (PositionY + (baseY + RandomNumberGenerator.GetInt32(-5, 5)) * 100),
-                                RandomNumberGenerator.GetInt32(0, 360));
-                            await _world.SpawnEntity(monster);
-
-                            groupInstance.Monsters.Add(monster);
-                            monster.Group = groupInstance;
-                        }
+                        await SpawnGroup(groupInstance, spawnPoint, group);
                     }
 
                     break;
                 }
                 case ESpawnPointType.Monster:
                 {
-                    int x, y;
-                    if (spawnPoint.RandomPosition)
-                    {
-                        // todo make sure monster doesn't spawn in non walkable area
-                        x = CoreRandom.GenerateInt32((int) (PositionX), (int) (PositionX + Width * MapUnit) + 1);
-                        y = CoreRandom.GenerateInt32((int) (PositionY), (int) (PositionY + Height * MapUnit) + 1);
-                    }
-                    else
-                    {
-                        x = (int)PositionX + (spawnPoint.X + CoreRandom.GenerateInt32(-spawnPoint.Range, spawnPoint.Range + 1)) * 100;
-                        y = (int)PositionY + (spawnPoint.Y + CoreRandom.GenerateInt32(-spawnPoint.Range, spawnPoint.Range + 1)) * 100;
-                    }
+                    var x = (int)PositionX + (spawnPoint.X + CoreRandom.GenerateInt32(-spawnPoint.RangeX, spawnPoint.RangeY + 1)) * 100;
+                    var y = (int)PositionY + (spawnPoint.Y + CoreRandom.GenerateInt32(-spawnPoint.RangeX, spawnPoint.RangeY + 1)) * 100;
 
                     spawnPoint.CurrentGroup = groupInstance;
 
                     var monster = new MonsterEntity(_monsterManager, _animationManager, _world, _logger, spawnPoint.Monster, x, y, (spawnPoint.Direction - 1) * 45);
                     await _world.SpawnEntity(monster);
-                    
+
                     groupInstance.Monsters.Add(monster);
                     monster.Group = groupInstance;
 
@@ -214,6 +204,26 @@ namespace QuantumCore.Game.World
                 default:
                     _logger.LogWarning("Unknown spawn point type: {SpawnPointType}", spawnPoint.Type);
                     break;
+            }
+        }
+
+        private async Task SpawnGroup(MonsterGroup groupInstance, SpawnPoint spawnPoint, SpawnGroup group)
+        {
+            var baseX = spawnPoint.X + RandomNumberGenerator.GetInt32(-spawnPoint.RangeX, spawnPoint.RangeY);
+            var baseY = spawnPoint.Y + RandomNumberGenerator.GetInt32(-spawnPoint.RangeX, spawnPoint.RangeY);
+
+            spawnPoint.CurrentGroup = groupInstance;
+
+            foreach (var member in group.Members)
+            {
+                var monster = new MonsterEntity(_monsterManager, _animationManager, _world, _logger, member.Id,
+                    (int) (PositionX + (baseX + RandomNumberGenerator.GetInt32(-5, 5)) * 100),
+                    (int) (PositionY + (baseY + RandomNumberGenerator.GetInt32(-5, 5)) * 100),
+                    RandomNumberGenerator.GetInt32(0, 360));
+                await _world.SpawnEntity(monster);
+
+                groupInstance.Monsters.Add(monster);
+                monster.Group = groupInstance;
             }
         }
 
@@ -246,7 +256,7 @@ namespace QuantumCore.Game.World
                     // if we aren't a player only players are relevant for nearby
                     filter = EEntityType.Player;
                 }
-                
+
                 _quadTree.QueryAround(nearby, entity.PositionX, entity.PositionY, Entity.ViewDistance, filter);
                 foreach (var e in nearby.Where(e => e != entity))
                 {
@@ -270,7 +280,7 @@ namespace QuantumCore.Game.World
         public void AddGroundItem(ItemInstance item, int x, int y, uint amount = 0)
         {
             var groundItem = new GroundItem(_animationManager, _world.GenerateVid(), item, amount) {
-                PositionX = x, 
+                PositionX = x,
                 PositionY = y
             };
 

--- a/Executables/Game/World/RemoteMap.cs
+++ b/Executables/Game/World/RemoteMap.cs
@@ -12,7 +12,7 @@ public class RemoteMap : IMap
     public uint UnitY => PositionY / Map.MapUnit;
     public uint Width { get; }
     public uint Height { get; }
-    
+
     public IPAddress Host { get; set; }
     public ushort Port { get; set; }
 
@@ -24,7 +24,7 @@ public class RemoteMap : IMap
         Width = width;
         Height = height;
     }
-    
+
     public List<IEntity> GetEntities()
     {
         throw new System.NotImplementedException();
@@ -50,8 +50,7 @@ public class RemoteMap : IMap
         return x >= PositionX && x < PositionX + Width * Map.MapUnit && y >= PositionY && y < PositionY + Height * Map.MapUnit;
     }
 
-    public ValueTask Update(double elapsedTime)
+    public void Update(double elapsedTime)
     {
-        return ValueTask.CompletedTask;
     }
 }

--- a/Executables/Game/World/RemoteMap.cs
+++ b/Executables/Game/World/RemoteMap.cs
@@ -12,6 +12,7 @@ public class RemoteMap : IMap
     public uint UnitY => PositionY / Map.MapUnit;
     public uint Width { get; }
     public uint Height { get; }
+    public IReadOnlyCollection<IEntity> Entities => throw new System.NotImplementedException();
 
     public IPAddress Host { get; set; }
     public ushort Port { get; set; }
@@ -35,12 +36,12 @@ public class RemoteMap : IMap
         throw new System.NotImplementedException();
     }
 
-    public bool SpawnEntity(IEntity entity)
+    public void SpawnEntity(IEntity entity)
     {
         throw new System.NotImplementedException();
     }
 
-    public Task DespawnEntity(IEntity entity)
+    public void DespawnEntity(IEntity entity)
     {
         throw new System.NotImplementedException();
     }

--- a/Executables/Game/World/Shop.cs
+++ b/Executables/Game/World/Shop.cs
@@ -68,7 +68,7 @@ public class Shop : IShop
 
         p.Shop = this;
         Visitors.Add(p);
-        
+
         var shopStart = new ShopOpen { Vid = Vid };
         foreach (var item in _items)
         {
@@ -80,7 +80,7 @@ public class Shop : IShop
                 Price = item.Price
             };
         }
-        await p.Connection.Send(shopStart);
+        p.Connection.Send(shopStart);
     }
 
     public async Task Buy(IPlayerEntity player, byte position, byte count)
@@ -89,7 +89,7 @@ public class Shop : IShop
         {
             return;
         }
-        
+
         // Look up item the player wants to buy
         var item = _items.Find(item => item.Position == position);
         if (item == null)
@@ -104,24 +104,24 @@ public class Shop : IShop
         var gold = p.GetPoint(EPoints.Gold);
         if (gold < item.Price)
         {
-            await p.Connection.Send(new ShopNotEnoughMoney());
+            p.Connection.Send(new ShopNotEnoughMoney());
             return;
         }
 
         // Create item instance
         var playerItem = _itemManager.CreateItem(proto, item.Count);
-        
+
         // todo set bonuses and sockets
-        
+
         // Try to place item into players inventory
         if (!await p.Inventory.PlaceItem(playerItem))
         {
-            await p.Connection.Send(new ShopNoSpaceLeft());
+            p.Connection.Send(new ShopNoSpaceLeft());
         }
-        await p.AddPoint(EPoints.Gold, -(int)item.Price);
+        p.AddPoint(EPoints.Gold, -(int)item.Price);
 
-        await p.SendPoints();
-        await p.SendItem(playerItem);
+        p.SendPoints();
+        p.SendItem(playerItem);
     }
 
     public async Task Sell(IPlayerEntity player, byte position)
@@ -143,10 +143,10 @@ public class Shop : IShop
             return;
         }
 
-        if (await p.DestroyItem(item))
+        if (p.DestroyItem(item))
         {
-            await p.AddPoint(EPoints.Gold, (int) proto.SellPrice);
-            await p.SendPoints();
+            p.AddPoint(EPoints.Gold, (int) proto.SellPrice);
+            p.SendPoints();
         }
     }
 
@@ -159,7 +159,7 @@ public class Shop : IShop
 
         p.Shop = null;
         Visitors.Remove(p);
-        
+
         // todo send close if flag specified
     }
 }

--- a/Executables/Game/World/SpawnPoint.cs
+++ b/Executables/Game/World/SpawnPoint.cs
@@ -1,22 +1,35 @@
+using System.Runtime.Serialization;
+
 namespace QuantumCore.Game.World
 {
     public enum ESpawnPointType
     {
+        [EnumMember(Value = "g")]
         Group,
-        Monster
+        [EnumMember(Value = "m")]
+        Monster,
+        [EnumMember(Value = "e")]
+        Exception,
+        [EnumMember(Value = "r")]
+        GroupCollection,
+        [EnumMember(Value = "s")]
+        Special
     }
-    
+
     public class SpawnPoint
     {
         public ESpawnPointType Type { get; set; }
-        public bool RandomPosition { get; set; }
+        public bool IsAggressive { get; set; }
         public int X { get; set; }
         public int Y { get; set; }
-        public int Range { get; set; }
+        public int RangeX { get; set; }
+        public int RangeY { get; set; }
         public int Direction { get; set; }
         public int RespawnTime { get; set; }
         public List<int> Groups { get; } = new List<int>();
         public uint Monster { get; set; }
         public MonsterGroup CurrentGroup { get; set; }
+        public short Chance { get; set; }
+        public short MaxAmount { get; set; }
     }
 }

--- a/Executables/Game/World/World.cs
+++ b/Executables/Game/World/World.cs
@@ -240,18 +240,17 @@ namespace QuantumCore.Game.World
             return _groupCollections[id];
         }
 
-        public bool SpawnEntity(IEntity e)
+        public void SpawnEntity(IEntity e)
         {
             var map = GetMapAt((uint) e.PositionX, (uint) e.PositionY);
-            if (map == null) return false;
+            if (map == null) return;
 
             if (e.GetType() == typeof(PlayerEntity))
                 AddPlayer((PlayerEntity)e);
 
             // _pluginExecutor.ExecutePlugins<IGameEntityLifetimeListener>(_logger, x => x.OnPreCreatedAsync()); // TODO
-            var result = map.SpawnEntity(e);
+            map.SpawnEntity(e);
             // _pluginExecutor.ExecutePlugins<IGameEntityLifetimeListener>(_logger, x => x.OnPostCreatedAsync()); // TODO
-            return result;
         }
 
         public void DespawnEntity(IEntity entity)

--- a/Executables/Game/World/World.cs
+++ b/Executables/Game/World/World.cs
@@ -162,13 +162,13 @@ namespace QuantumCore.Game.World
             _mapSubscriber.Listen();
         }
 
-        public async Task Update(double elapsedTime)
+        public void Update(double elapsedTime)
         {
             // HookManager.Instance.CallHook<IHookWorldUpdate>(elapsedTime);
 
             foreach (var map in _maps.Values)
             {
-                await map.Update(elapsedTime);
+                map.Update(elapsedTime);
             }
         }
 
@@ -240,7 +240,7 @@ namespace QuantumCore.Game.World
             return _groupCollections[id];
         }
 
-        public async ValueTask<bool> SpawnEntity(IEntity e)
+        public bool SpawnEntity(IEntity e)
         {
             var map = GetMapAt((uint) e.PositionX, (uint) e.PositionY);
             if (map == null) return false;
@@ -248,22 +248,22 @@ namespace QuantumCore.Game.World
             if (e.GetType() == typeof(PlayerEntity))
                 AddPlayer((PlayerEntity)e);
 
-            await _pluginExecutor.ExecutePlugins<IGameEntityLifetimeListener>(_logger, x => x.OnPreCreatedAsync());
+            // _pluginExecutor.ExecutePlugins<IGameEntityLifetimeListener>(_logger, x => x.OnPreCreatedAsync()); // TODO
             var result = map.SpawnEntity(e);
-            await _pluginExecutor.ExecutePlugins<IGameEntityLifetimeListener>(_logger, x => x.OnPostCreatedAsync());
+            // _pluginExecutor.ExecutePlugins<IGameEntityLifetimeListener>(_logger, x => x.OnPostCreatedAsync()); // TODO
             return result;
         }
 
-        public async Task DespawnEntity(IEntity entity)
+        public void DespawnEntity(IEntity entity)
         {
             if (entity is IPlayerEntity player)
             {
                 RemovePlayer(player);
             }
 
-            await _pluginExecutor.ExecutePlugins<IGameEntityLifetimeListener>(_logger, x => x.OnPreDeletedAsync());
+            // await _pluginExecutor.ExecutePlugins<IGameEntityLifetimeListener>(_logger, x => x.OnPreDeletedAsync()); // TODO
             entity.Map?.DespawnEntity(entity);
-            await _pluginExecutor.ExecutePlugins<IGameEntityLifetimeListener>(_logger, x => x.OnPostDeletedAsync());
+            // await _pluginExecutor.ExecutePlugins<IGameEntityLifetimeListener>(_logger, x => x.OnPostDeletedAsync()); // TODO
         }
 
         public uint GenerateVid()

--- a/Executables/Game/World/World.cs
+++ b/Executables/Game/World/World.cs
@@ -162,13 +162,13 @@ namespace QuantumCore.Game.World
             _mapSubscriber.Listen();
         }
 
-        public void Update(double elapsedTime)
+        public async Task Update(double elapsedTime)
         {
             // HookManager.Instance.CallHook<IHookWorldUpdate>(elapsedTime);
 
             foreach (var map in _maps.Values)
             {
-                map.Update(elapsedTime);
+                await map.Update(elapsedTime);
             }
         }
 

--- a/Executables/Game/appsettings.json
+++ b/Executables/Game/appsettings.json
@@ -1,4 +1,12 @@
 ﻿{
+    "Serilog": {
+        "MinimumLevel": {
+            "Override": {
+                "QuantumCore.Auth": "Warning",
+                "QuantumCore.Game": "Warning"
+            }
+        }
+    },
     "Hosting": {
         "Port": 13001
     },

--- a/Game.Benchmarks/Benchmarks/WorldUpdateBenchmark.cs
+++ b/Game.Benchmarks/Benchmarks/WorldUpdateBenchmark.cs
@@ -125,10 +125,11 @@ public class WorldUpdateBenchmark
             var entity = ActivatorUtilities.CreateInstance<PlayerEntity>(services, _world, player, conn);
             _world.SpawnEntity(entity);
         }
-        foreach (var e in _world.GetMapAt(0, 0).GetEntities())
+        foreach (var e in _world.GetMapAt(0, 0).Entities)
         {
-            e.Goto(0, 0);
+            e?.Goto(0, 0);
         }
+        _world.Update(0.2); // spawn entities
     }
 
     [Benchmark]

--- a/Game.Benchmarks/Benchmarks/WorldUpdateBenchmark.cs
+++ b/Game.Benchmarks/Benchmarks/WorldUpdateBenchmark.cs
@@ -1,0 +1,139 @@
+﻿using System.Data;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using QuantumCore;
+using QuantumCore.API;
+using QuantumCore.API.Core.Models;
+using QuantumCore.API.Game.World;
+using QuantumCore.Core.Cache;
+using QuantumCore.Database;
+using QuantumCore.Extensions;
+using QuantumCore.Game;
+using QuantumCore.Game.Extensions;
+using QuantumCore.Game.PlayerUtils;
+using QuantumCore.Game.Services;
+using QuantumCore.Game.World;
+using QuantumCore.Game.World.Entities;
+using Weikio.PluginFramework.Catalogs;
+
+namespace Game.Benchmarks.Benchmarks;
+
+[MemoryDiagnoser]
+[MediumRunJob]
+public class WorldUpdateBenchmark
+{
+    [Params(0, 100, 1000)]
+    public int MobAmount;
+
+    [Params(0, 1, 10)]
+    public int PlayerAmount;
+
+    private World _world = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>())
+            .Build();
+        var services = new ServiceCollection()
+            .AddLogging()
+            .AddSingleton<IConfiguration>(_ => config)
+            .AddCoreServices(new EmptyPluginCatalog(), config)
+            .AddQuantumCoreCache()
+            .AddQuantumCoreDatabase()
+            .AddGameServices()
+            .Replace(new ServiceDescriptor(typeof(IDbConnection), _ => new Mock<IDbConnection>().Object, ServiceLifetime.Singleton))
+            .Replace(new ServiceDescriptor(typeof(IAtlasProvider), provider =>
+            {
+                var mock = new Mock<IAtlasProvider>();
+                mock.Setup(x => x.GetAsync(It.IsAny<IWorld>())).ReturnsAsync<IWorld, IAtlasProvider, IEnumerable<IMap>>(world => new []
+                {
+                    new Map(provider.GetRequiredService<IMonsterManager>(),
+                        provider.GetRequiredService<IAnimationManager>(),
+                        provider.GetRequiredService<ICacheManager>(), world,
+                        provider.GetRequiredService<IOptions<HostingOptions>>(),
+                        provider.GetRequiredService<ILogger<Map>>(),
+                        provider.GetRequiredService<ISpawnPointProvider>(), "test_map", 0, 0, 1024, 1024)
+                });
+                return mock.Object;
+            }, ServiceLifetime.Singleton))
+            .Replace(new ServiceDescriptor(typeof(ICacheManager), _ =>
+            {
+                var mock = new Mock<ICacheManager>();
+                mock.Setup(x => x.Keys("maps:*")).ReturnsAsync(new []{"maps:test_map"});
+                mock.Setup(x => x.Subscribe()).Returns(new Mock<IRedisSubscriber>().Object);
+                return mock.Object;
+            }, ServiceLifetime.Singleton))
+            .Replace(new ServiceDescriptor(typeof(ISpawnPointProvider), _ =>
+            {
+                var mock = new Mock<ISpawnPointProvider>();
+                mock.Setup(x => x.GetSpawnPointsForMap("test_map")).ReturnsAsync(Enumerable
+                    .Range(0, MobAmount)
+                    .Select(_ =>
+                        new SpawnPoint
+                        {
+                            Chance = 100,
+                            Type = ESpawnPointType.Monster,
+                            Monster = 42,
+                            X = 1,
+                            Y = 1,
+                            RangeX = 0,
+                            RangeY = 0
+                        }
+                    )
+                    .ToArray()
+                );
+                return mock.Object;
+            }, ServiceLifetime.Singleton))
+            .Replace(new ServiceDescriptor(typeof(IJobManager), _ =>
+            {
+                var mock = new Mock<IJobManager>();
+                mock.Setup(x => x.Get(1)).Returns(new Job());
+                return mock.Object;
+            }, ServiceLifetime.Singleton))
+            .Replace(new ServiceDescriptor(typeof(IMonsterManager), _ =>
+            {
+                var mock = new Mock<IMonsterManager>();
+                mock.Setup(x => x.GetMonster(42)).Returns(new MonsterData
+                {
+                    Type = (byte)EEntityType.Monster
+                });
+                return mock.Object;
+            }, ServiceLifetime.Singleton))
+            .BuildServiceProvider();
+        _world = ActivatorUtilities.CreateInstance<World>(services);
+        ActivatorUtilities.CreateInstance<GameServer>(services); // for setting the singleton GameServer.Instance
+        _world.Load().Wait();
+
+        foreach (var i in Enumerable.Range(0, PlayerAmount))
+        {
+            var player = new Player
+            {
+                Name = i.ToString(),
+                PlayerClass = 1,
+                PositionX = 1,
+                PositionY = 1
+            };
+            var connMock = new Mock<IGameConnection>();
+            var conn = connMock.Object;
+            var entity = ActivatorUtilities.CreateInstance<PlayerEntity>(services, _world, player, conn);
+            _world.SpawnEntity(entity).AsTask().Wait();
+        }
+        foreach (var e in _world.GetMapAt(0, 0).GetEntities())
+        {
+            e.Goto(0, 0).Wait();
+        }
+    }
+
+    [Benchmark]
+    public async Task World_Tick()
+    {
+        await _world.Update(0.2);
+    }
+}

--- a/Game.Benchmarks/Game.Benchmarks.csproj
+++ b/Game.Benchmarks/Game.Benchmarks.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="BenchmarkDotNet" Version="0.13.9" />
+      <PackageReference Include="Moq" Version="4.18.2" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Executables\Game\Game.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Game.Benchmarks/Program.cs
+++ b/Game.Benchmarks/Program.cs
@@ -1,0 +1,4 @@
+﻿using BenchmarkDotNet.Running;
+using Game.Benchmarks.Benchmarks;
+
+BenchmarkRunner.Run<WorldUpdateBenchmark>();

--- a/Game.Benchmarks/Program.cs
+++ b/Game.Benchmarks/Program.cs
@@ -2,3 +2,4 @@
 using Game.Benchmarks.Benchmarks;
 
 BenchmarkRunner.Run<WorldUpdateBenchmark>();
+// BenchmarkRunner.Run<PlayerEntityBenchmarks>();

--- a/Game.Tests/Game.Tests.csproj
+++ b/Game.Tests/Game.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="6.11.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2"/>
+        <PackageReference Include="NSubstitute" Version="5.1.0" />
+        <PackageReference Include="xunit" Version="2.4.2"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Executables\Game\Game.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Game.Tests/Usings.cs
+++ b/Game.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/Game.Tests/World.cs
+++ b/Game.Tests/World.cs
@@ -122,4 +122,11 @@ public class WorldTests
         _world.Update(0.2);
         Assert.True(true);
     }
+
+    [Fact]
+    public void Player_Update()
+    {
+        _playerEntity.Update(1);
+        Assert.True(true);
+    }
 }

--- a/Game.Tests/WorldTests.cs
+++ b/Game.Tests/WorldTests.cs
@@ -114,6 +114,7 @@ public class WorldTests
         };
         _playerEntity = ActivatorUtilities.CreateInstance<PlayerEntity>(services, _world, playerData, conn);
         _world.SpawnEntity(_playerEntity);
+        _world.Update(0.2); // spawn all entities
     }
 
     [Fact]

--- a/Plugins/ExamplePlugin/TestCommand.cs
+++ b/Plugins/ExamplePlugin/TestCommand.cs
@@ -8,21 +8,21 @@ namespace ExamplePlugin
     public static class TestCommand
     {
         [CommandMethod("Plain command without any parameter")]
-        public static async Task Run(IPlayerEntity player)
+        public static void Run(IPlayerEntity player)
         {
-            await player.SendChatInfo("Test command works!");
+            player.SendChatInfo("Test command works!");
         }
 
         [CommandMethod("This command tests the handler with more than one argument")]
-        public static async Task Run(IPlayerEntity player, int required1, string optional1 = "")
+        public static void Run(IPlayerEntity player, int required1, string optional1 = "")
         {
-            await player.SendChatInfo($"Test command sent with parameters {required1} and {optional1}");
+            player.SendChatInfo($"Test command sent with parameters {required1} and {optional1}");
         }
 
         [CommandMethod("This command tests the float type")]
-        public static async Task Run(IPlayerEntity player, float required1, string optional1 = "")
+        public static void Run(IPlayerEntity player, float required1, string optional1 = "")
         {
-            await player.SendChatInfo($"Test command sent with parameters {required1} and {optional1}");
+            player.SendChatInfo($"Test command sent with parameters {required1} and {optional1}");
         }
     }
 }

--- a/QuantumCore.sln
+++ b/QuantumCore.sln
@@ -30,6 +30,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Weikio.PluginFramework.Micr
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Game.Benchmarks", "Game.Benchmarks\Game.Benchmarks.csproj", "{08C823FA-CE25-4A3A-950E-1318EF8FD820}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Game.Tests", "Game.Tests\Game.Tests.csproj", "{0051033D-1CCB-460C-9E3D-7027141B437A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -88,6 +90,10 @@ Global
 		{08C823FA-CE25-4A3A-950E-1318EF8FD820}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{08C823FA-CE25-4A3A-950E-1318EF8FD820}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{08C823FA-CE25-4A3A-950E-1318EF8FD820}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0051033D-1CCB-460C-9E3D-7027141B437A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0051033D-1CCB-460C-9E3D-7027141B437A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0051033D-1CCB-460C-9E3D-7027141B437A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0051033D-1CCB-460C-9E3D-7027141B437A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{930E5131-B018-4255-BC08-ACE8F2C1BAC5} = {6D101418-9A2D-41CB-BEA9-47F915395CE8}

--- a/QuantumCore.sln
+++ b/QuantumCore.sln
@@ -28,6 +28,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core.Networking.Generators.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Weikio.PluginFramework.Microsoft.DependencyInjection", "Weikio.PluginFramework.Microsoft.DependencyInjection\Weikio.PluginFramework.Microsoft.DependencyInjection.csproj", "{84A82103-9C4B-4224-9DF8-53F5E74C0AF7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Game.Benchmarks", "Game.Benchmarks\Game.Benchmarks.csproj", "{08C823FA-CE25-4A3A-950E-1318EF8FD820}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -82,6 +84,10 @@ Global
 		{84A82103-9C4B-4224-9DF8-53F5E74C0AF7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{84A82103-9C4B-4224-9DF8-53F5E74C0AF7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{84A82103-9C4B-4224-9DF8-53F5E74C0AF7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{08C823FA-CE25-4A3A-950E-1318EF8FD820}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{08C823FA-CE25-4A3A-950E-1318EF8FD820}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{08C823FA-CE25-4A3A-950E-1318EF8FD820}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{08C823FA-CE25-4A3A-950E-1318EF8FD820}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{930E5131-B018-4255-BC08-ACE8F2C1BAC5} = {6D101418-9A2D-41CB-BEA9-47F915395CE8}


### PR DESCRIPTION
This PR depends on #21 

I created benchmarks in the `Game.Benchmarks` project. These can be executed on the master branch as well (some minor adjustments needed). These benchmark results show massive improvements in tick time and allocations.

## Before

| Method     | MobAmount | PlayerAmount | Mean         | Error        | StdDev       | Gen0   | Gen1   | Allocated |
|----------- |---------- |------------- |-------------:|-------------:|-------------:|-------:|-------:|----------:|
| World_Tick | 0         | 0            |     64.42 ns |     1.850 ns |     2.770 ns |      - |      - |         - |
| World_Tick | 0         | 1            |  1,491.87 ns |    25.327 ns |    37.908 ns | 0.0896 | 0.0305 |     752 B |
| World_Tick | 0         | 10           | 14,845.21 ns |   721.294 ns | 1,057.264 ns | 0.8545 | 0.2747 |    7304 B |
| World_Tick | 100       | 0            |    700.16 ns |     3.674 ns |     5.028 ns | 0.0219 |      - |     184 B |
| World_Tick | 100       | 1            |  2,435.19 ns |    57.915 ns |    86.685 ns | 0.1068 | 0.0343 |     912 B |
| World_Tick | 100       | 10           | 15,474.01 ns |   659.433 ns |   966.588 ns | 0.8850 | 0.3052 |    7464 B |
| World_Tick | 1000      | 0            |    714.64 ns |     7.332 ns |    10.279 ns | 0.0219 |      - |     184 B |
| World_Tick | 1000      | 1            |  2,558.69 ns |   219.188 ns |   321.284 ns | 0.1068 | 0.0343 |     912 B |
| World_Tick | 1000      | 10           | 18,889.50 ns | 1,817.647 ns | 2,720.568 ns | 0.8850 | 0.3052 |    7464 B |

![image](https://github.com/MeikelLP/quantum-core-x/assets/11669846/1675f19f-4235-4ce0-bdd0-212f2f6e92b5)


## After

| Method     | MobAmount | PlayerAmount | Mean      | Error    | StdDev   | Median    | Allocated |
|----------- |---------- |------------- |----------:|---------:|---------:|----------:|----------:|
| World_Tick | 0         | 0            |  16.96 ns | 0.049 ns | 0.065 ns |  16.94 ns |         - |
| World_Tick | 0         | 1            |  26.09 ns | 0.570 ns | 0.799 ns |  25.52 ns |         - |
| World_Tick | 0         | 10           | 127.43 ns | 0.439 ns | 0.601 ns | 127.48 ns |         - |
| World_Tick | 100       | 0            | 213.19 ns | 1.000 ns | 1.497 ns | 213.10 ns |         - |
| World_Tick | 100       | 1            | 245.09 ns | 0.899 ns | 1.260 ns | 245.26 ns |         - |
| World_Tick | 100       | 10           | 332.89 ns | 2.116 ns | 3.101 ns | 331.81 ns |         - |
| World_Tick | 1000      | 0            | 213.36 ns | 0.908 ns | 1.273 ns | 213.23 ns |         - |
| World_Tick | 1000      | 1            | 245.70 ns | 0.609 ns | 0.834 ns | 245.53 ns |         - |
| World_Tick | 1000      | 10           | 332.92 ns | 1.640 ns | 2.403 ns | 332.01 ns |         - |

![image](https://github.com/MeikelLP/quantum-core-x/assets/11669846/b9a785f8-013c-4383-9bbc-5fd9271c207e)

## Changes

The following changes where made:

* Improve `PlayerEntity.GetPoint` by preloading values and just returning the current state. Weapon damage may change if the item is switched. An event has been created in the `Inventory` class
* Some closure improvements by not using LINQ
* Replaced all async calls with sync calls which for sending packages will write to a concurrent queue instead of directly writing to the network. A background task is started which will try to process the queue or wait for 1ms if none exists. Packets will come in quite frequently that's why the wait time is so small.
