### PR TITLE
Implement command to reload the current loaded permissions

### DIFF
--- a/src/CorePluginAPI/Game/World/IPlayerEntity.cs
+++ b/src/CorePluginAPI/Game/World/IPlayerEntity.cs
@@ -19,6 +19,7 @@ namespace QuantumCore.API.Game.World
         EAntiFlags AntiFlagGender { get; }
 
         Task Load();
+        Task ReloadPermissions();
         T? GetQuestInstance<T>() where T : class, IQuest;
         void Respawn(bool town);
         uint CalculateAttackDamage(uint baseDamage);

--- a/src/CorePluginAPI/Game/World/IWorld.cs
+++ b/src/CorePluginAPI/Game/World/IWorld.cs
@@ -21,5 +21,6 @@ namespace QuantumCore.API.Game.World
         uint GenerateVid();
         void RemovePlayer(IPlayerEntity e);
         IPlayerEntity? GetPlayer(string playerName);
+        IList<IPlayerEntity> GetPlayers();
     }
 }

--- a/src/Executables/Game/Commands/CommandManager.cs
+++ b/src/Executables/Game/Commands/CommandManager.cs
@@ -128,6 +128,12 @@ namespace QuantumCore.Game.Commands
             await ParseGroup(Operator_Group, "Operator");
         }
 
+        public async Task ReloadAsync(CancellationToken token = default)
+        {
+            Groups.Clear();
+            await LoadAsync(token);
+        }
+
         public bool HavePerm(Guid group, string cmd)
         {
             if (!Groups.ContainsKey(group))

--- a/src/Executables/Game/Commands/ICommandManager.cs
+++ b/src/Executables/Game/Commands/ICommandManager.cs
@@ -9,6 +9,7 @@ public interface ICommandManager
 {
     void Register(string ns, Assembly? assembly = null);
     Task LoadAsync(CancellationToken token = default);
+    Task ReloadAsync(CancellationToken token = default);
     bool HavePerm(Guid group, string cmd);
     bool CanUseCommand(IPlayerEntity player, string cmd);
     Task Handle(IGameConnection connection, string chatline);

--- a/src/Executables/Game/Commands/ReloadPermissionsCommand.cs
+++ b/src/Executables/Game/Commands/ReloadPermissionsCommand.cs
@@ -1,0 +1,43 @@
+﻿using CommandLine;
+using QuantumCore.API.Game;
+using QuantumCore.API.Game.World;
+
+namespace QuantumCore.Game.Commands;
+
+[Command("reload_perms", "Reloads the permissions of the target player or all players if no target is specified")]
+[CommandNoPermission]
+public class ReloadPermissionsCommand : ICommandHandler<ReloadPermissionsCommandOptions>
+{
+    private readonly IWorld _world;
+    private readonly ICommandManager _commandManager;
+
+    public ReloadPermissionsCommand(IWorld world, ICommandManager commandManager)
+    {
+        _world = world;
+        _commandManager = commandManager;
+    }
+    
+    public async Task ExecuteAsync(CommandContext<ReloadPermissionsCommandOptions> context)
+    {
+        var target = string.Equals(context.Arguments.Target, "$self", StringComparison.InvariantCultureIgnoreCase)
+            ? context.Player
+            : _world.GetPlayer(context.Arguments.Target);
+     
+        if (target is not null)
+        {
+            await target.ReloadPermissions();
+        }
+        else
+        {
+            var players = _world.GetPlayers();
+            await Task.WhenAll(players.Select(x => x.ReloadPermissions()));
+        }
+
+        await _commandManager.ReloadAsync();
+    }
+}
+
+public class ReloadPermissionsCommandOptions
+{
+    [Value(0)] public string Target { get; set; }
+}

--- a/src/Executables/Game/Commands/ReloadPermissionsCommand.cs
+++ b/src/Executables/Game/Commands/ReloadPermissionsCommand.cs
@@ -19,10 +19,14 @@ public class ReloadPermissionsCommand : ICommandHandler<ReloadPermissionsCommand
     
     public async Task ExecuteAsync(CommandContext<ReloadPermissionsCommandOptions> context)
     {
+        // Reload in-memory + cache permissions
+        await _commandManager.ReloadAsync();
+        
         var target = string.Equals(context.Arguments.Target, "$self", StringComparison.InvariantCultureIgnoreCase)
             ? context.Player
             : _world.GetPlayer(context.Arguments.Target);
-     
+        
+        // Reload permissions for target player or all players
         if (target is not null)
         {
             await target.ReloadPermissions();
@@ -32,8 +36,8 @@ public class ReloadPermissionsCommand : ICommandHandler<ReloadPermissionsCommand
             var players = _world.GetPlayers();
             await Task.WhenAll(players.Select(x => x.ReloadPermissions()));
         }
-
-        await _commandManager.ReloadAsync();
+        
+        context.Player.SendChatInfo("Permissions reloaded");
     }
 }
 

--- a/src/Executables/Game/World/Entities/PlayerEntity.cs
+++ b/src/Executables/Game/World/Entities/PlayerEntity.cs
@@ -154,6 +154,12 @@ namespace QuantumCore.Game.World.Entities
 
             CalculateDefence();
         }
+        
+        public async Task ReloadPermissions()
+        {
+            Groups.Clear();
+            await LoadPermGroups();
+        }
 
         private async Task LoadPermGroups()
         {

--- a/src/Executables/Game/World/World.cs
+++ b/src/Executables/Game/World/World.cs
@@ -312,7 +312,16 @@ namespace QuantumCore.Game.World
 
         public IPlayerEntity? GetPlayer(string playerName)
         {
-            return _players.ContainsKey(playerName) ? _players[playerName] : null;
+            if (string.IsNullOrWhiteSpace(playerName))
+            {
+                return null;
+            }
+            return _players.TryGetValue(playerName, out var player) ? player : null;
+        }
+
+        public IList<IPlayerEntity> GetPlayers()
+        {
+            return _players.Values.ToList();
         }
     }
 }

--- a/src/Tests/Core.Tests/CommandTests.cs
+++ b/src/Tests/Core.Tests/CommandTests.cs
@@ -547,12 +547,12 @@ public class CommandTests : IAsyncLifetime
             Name = groupName,
             Permissions = newPermissions
         });
+
+        await _commandManager.ReloadAsync();
         
-        _player.ReloadPermissions().Should().Be(Task.CompletedTask);
-            
-        _commandManager.ReloadAsync().Should().Be(Task.CompletedTask);
+        await _player.ReloadPermissions();
         
-        (_connection as MockedGameConnection).SentMessages.Should().ContainEquivalentOf(new ChatOutcoming
+        ((MockedGameConnection)_connection).SentMessages.Should().ContainEquivalentOf(new ChatOutcoming
         {
             Message = "Permissions reloaded"
         }, cfg => cfg.Including(x => x.Message));

--- a/src/Tests/Core.Tests/CommandTests.cs
+++ b/src/Tests/Core.Tests/CommandTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using NSubstitute;
 using QuantumCore.API;
 using QuantumCore.API.Core.Models;
+using QuantumCore.API.Game;
 using QuantumCore.API.Game.Types;
 using QuantumCore.API.Game.World;
 using QuantumCore.Caching;
@@ -519,5 +520,41 @@ public class CommandTests : IAsyncLifetime
         var world = _services.GetRequiredService<IWorld>();
         await world.Load();
         return world;
+    }
+    
+    [Fact]
+    public async Task ReloadPermissionsCommand_WithoutTarget()
+    {
+        // Prepare
+        var updatedGroup = Guid.NewGuid();
+        var groupName = "test";
+        
+        var newPermissions = new[] { "reload_perms", "goto" };
+        _services.GetRequiredService<ICommandPermissionRepository>().GetPermissionsForGroupAsync(Arg.Any<Guid>()).Returns(newPermissions);
+        _services.GetRequiredService<ICommandPermissionRepository>().GetGroupsAsync().Returns(new[] { (updatedGroup, groupName) });
+        
+        _services.GetRequiredService<ICacheManager>().CreateList<Guid>(Arg.Any<string>())
+            .Range(0, 0).Returns(new[] { updatedGroup });
+        
+        // Act
+        await _commandManager.Handle(_connection, "/reload_perms");
+
+        // Assert
+        _commandManager.Groups.Keys.Should().Contain(updatedGroup);
+        _commandManager.Groups.Values.Should().ContainEquivalentOf(new PermissionGroup
+        {
+            Id = updatedGroup,
+            Name = groupName,
+            Permissions = newPermissions
+        });
+        
+        _player.ReloadPermissions().Should().Be(Task.CompletedTask);
+            
+        _commandManager.ReloadAsync().Should().Be(Task.CompletedTask);
+        
+        (_connection as MockedGameConnection).SentMessages.Should().ContainEquivalentOf(new ChatOutcoming
+        {
+            Message = "Permissions reloaded"
+        }, cfg => cfg.Including(x => x.Message));
     }
 }


### PR DESCRIPTION
The general ideia is to be able to reload the currently loaded player groups, while also providing a way to reload what actual permissions belong to any group without having to restart the game server.

We can specifically target a single player, or all the connected players (default).