### PR TITLE
Use ChatInfo instead of ChatMessage when target is not found

### DIFF
--- a/src/Executables/Game/Commands/GiveItemCommand.cs
+++ b/src/Executables/Game/Commands/GiveItemCommand.cs
@@ -30,7 +30,7 @@ namespace QuantumCore.Game.Commands
 
             if (target is null)
             {
-                context.Player.SendChatMessage("Target not found");
+                context.Player.SendChatInfo("Target not found");
             }
             else
             {

--- a/src/Tests/Core.Tests/CommandTests.cs
+++ b/src/Tests/Core.Tests/CommandTests.cs
@@ -286,6 +286,17 @@ public class CommandTests : IAsyncLifetime
             Count = 10
         }, cfg => cfg.Including(x => x.ItemId).Including(x => x.Count));
     }
+    
+    [Fact]
+    public async Task GiveItemCommand_InvalidPlayer()
+    {
+        await _commandManager.Handle(_connection, "/give missing 1 10");
+
+        (_connection as MockedGameConnection).SentMessages.Should().ContainEquivalentOf(new ChatOutcoming
+        {
+            Message = "Target not found"
+        }, cfg => cfg.Including(x => x.Message));
+    }
 
     [Fact]
     public async Task GoldCommand_Self()

--- a/src/Tests/Core.Tests/CommandTests.cs
+++ b/src/Tests/Core.Tests/CommandTests.cs
@@ -292,7 +292,7 @@ public class CommandTests : IAsyncLifetime
     {
         await _commandManager.Handle(_connection, "/give missing 1 10");
 
-        (_connection as MockedGameConnection).SentMessages.Should().ContainEquivalentOf(new ChatOutcoming
+        ((MockedGameConnection)_connection).SentMessages.Should().ContainEquivalentOf(new ChatOutcoming
         {
             Message = "Target not found"
         }, cfg => cfg.Including(x => x.Message));


### PR DESCRIPTION
GiveItem command was incorrectly sending a normal chat message when the Target player is not found.

Now it sends a ChatInfo message visible only to the player.