### PR TITLE
FIX permission group reload

### DIFF
--- a/src/Core/Extensions/ServiceExtensions.cs
+++ b/src/Core/Extensions/ServiceExtensions.cs
@@ -21,7 +21,8 @@ public static class ServiceExtensions
     /// <param name="services"></param>
     /// <param name="pluginCatalog"></param>
     /// <returns></returns>
-    public static IServiceCollection AddCoreServices(this IServiceCollection services, IPluginCatalog pluginCatalog, IConfiguration configuration)
+    public static IServiceCollection AddCoreServices(this IServiceCollection services, IPluginCatalog pluginCatalog,
+        IConfiguration configuration)
     {
         services.AddOptions<HostingOptions>()
             .BindConfiguration("Hosting")
@@ -37,10 +38,10 @@ public static class ServiceExtensions
             var handlerTypes = AppDomain.CurrentDomain.GetAssemblies().SelectMany(x => x.ExportedTypes)
                 .Where(x =>
                     x.IsAssignableTo(typeof(IPacketHandler)) &&
-                    x is { IsClass: true, IsAbstract: false, IsInterface: false })
+                    x is {IsClass: true, IsAbstract: false, IsInterface: false})
                 .OrderBy(x => x.FullName)
                 .ToArray();
-            return ActivatorUtilities.CreateInstance<PacketManager>(provider, new object[] { (IEnumerable<Type>)packetTypes, handlerTypes });
+            return ActivatorUtilities.CreateInstance<PacketManager>(provider, [packetTypes, handlerTypes]);
         });
         services.AddSingleton<IPacketReader, PacketReader>();
         services.AddSingleton<PluginExecutor>();

--- a/src/Data/Game.Persistence/CommandPermissionRepository.cs
+++ b/src/Data/Game.Persistence/CommandPermissionRepository.cs
@@ -8,6 +8,7 @@ public interface ICommandPermissionRepository
     Task<IEnumerable<string>> GetPermissionsForGroupAsync(Guid groupId);
     Task<IEnumerable<Guid>> GetPlayerIdsInGroupAsync(Guid groupId);
     Task<IEnumerable<PermissionGroup>> GetGroupsAsync();
+    Task<IEnumerable<Guid>> GetGroupsForPlayer(Guid playerId);
 }
 
 public class CommandPermissionRepository : ICommandPermissionRepository
@@ -17,6 +18,14 @@ public class CommandPermissionRepository : ICommandPermissionRepository
     public CommandPermissionRepository(GameDbContext db)
     {
         _db = db;
+    }
+
+    public async Task<IEnumerable<Guid>> GetGroupsForPlayer(Guid playerId)
+    {
+        return await _db.PermissionUsers
+            .Where(x => x.PlayerId == playerId)
+            .Select(x => x.GroupId)
+            .ToArrayAsync();
     }
 
     public async Task<IEnumerable<string>> GetPermissionsForGroupAsync(Guid groupId)

--- a/src/Executables/Game/Extensions/ServiceExtensions.cs
+++ b/src/Executables/Game/Extensions/ServiceExtensions.cs
@@ -33,6 +33,7 @@ public static class ServiceExtensions
             http.BaseAddress = new Uri(options.BaseUrl);
         });
         services.AddScoped<IPlayerManager, PlayerManager>();
+        services.AddSingleton<IPlayerFactory, PlayerFactory>();
         services.AddSingleton<ISpawnGroupProvider, SpawnGroupProvider>();
         services.AddSingleton<ISpawnPointProvider, SpawnPointProvider>();
         services.AddSingleton<IItemManager, ItemManager>();

--- a/src/Executables/Game/IPlayerFactory.cs
+++ b/src/Executables/Game/IPlayerFactory.cs
@@ -1,0 +1,13 @@
+﻿using QuantumCore.API;
+using QuantumCore.API.Core.Models;
+using QuantumCore.API.Game.World;
+
+namespace QuantumCore.Game;
+
+public interface IPlayerFactory
+{
+    /// <summary>
+    /// Creates a player entity and triggers the loads additional data before returning the entity itself.
+    /// </summary>
+    Task<IPlayerEntity> CreatePlayerAsync(IGameConnection connection, PlayerData player);
+}

--- a/src/Executables/Game/PacketHandlers/Select/SelectGameCharacterHandler.cs
+++ b/src/Executables/Game/PacketHandlers/Select/SelectGameCharacterHandler.cs
@@ -1,26 +1,24 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using QuantumCore.API;
 using QuantumCore.API.Game.Types;
 using QuantumCore.API.PluginTypes;
 using QuantumCore.Extensions;
 using QuantumCore.Game.Packets;
-using QuantumCore.Game.World.Entities;
 
 namespace QuantumCore.Game.PacketHandlers.Select;
 
 public class SelectGameCharacterHandler : IGamePacketHandler<SelectCharacter>
 {
     private readonly ILogger<SelectGameCharacterHandler> _logger;
-    private readonly IServiceProvider _provider;
     private readonly IPlayerManager _playerManager;
+    private readonly IPlayerFactory _playerFactory;
 
-    public SelectGameCharacterHandler(ILogger<SelectGameCharacterHandler> logger, IServiceProvider provider,
-        IPlayerManager playerManager)
+    public SelectGameCharacterHandler(ILogger<SelectGameCharacterHandler> logger,
+        IPlayerManager playerManager, IPlayerFactory playerFactory)
     {
         _logger = logger;
-        _provider = provider;
         _playerManager = playerManager;
+        _playerFactory = playerFactory;
     }
 
     public async Task ExecuteAsync(GamePacketContext<SelectCharacter> ctx, CancellationToken token = default)
@@ -46,8 +44,7 @@ public class SelectGameCharacterHandler : IGamePacketHandler<SelectCharacter>
             throw new InvalidOperationException("Player was not found. This should never happen at this point");
         }
 
-        var entity = ActivatorUtilities.CreateInstance<PlayerEntity>(_provider, ctx.Connection, player);
-        await entity.Load();
+        var entity = await _playerFactory.CreatePlayerAsync(ctx.Connection, player);
 
         ctx.Connection.Player = entity;
 

--- a/src/Executables/Game/PlayerFactory.cs
+++ b/src/Executables/Game/PlayerFactory.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using QuantumCore.API;
+using QuantumCore.API.Core.Models;
+using QuantumCore.API.Game.World;
+using QuantumCore.Game.World.Entities;
+
+namespace QuantumCore.Game;
+
+/// <summary>
+/// Singleton which can create a player for a given connection
+/// </summary>
+public class PlayerFactory : IPlayerFactory
+{
+    private readonly IServiceProvider _provider;
+
+    public PlayerFactory(IServiceProvider provider)
+    {
+        _provider = provider;
+    }
+
+    public async Task<IPlayerEntity> CreatePlayerAsync(IGameConnection connection, PlayerData player)
+    {
+        var entity = ActivatorUtilities.CreateInstance<PlayerEntity>(_provider, [connection, player]);
+        await entity.Load();
+
+        return entity;
+    }
+}

--- a/src/Executables/Game/World/Entities/PlayerEntity.cs
+++ b/src/Executables/Game/World/Entities/PlayerEntity.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using QuantumCore.API;
 using QuantumCore.API.Core.Models;
@@ -13,7 +14,7 @@ using QuantumCore.Game.PlayerUtils;
 
 namespace QuantumCore.Game.World.Entities
 {
-    public class PlayerEntity : Entity, IPlayerEntity
+    public class PlayerEntity : Entity, IPlayerEntity, IDisposable
     {
         public override EEntityType Type => EEntityType.Player;
 
@@ -28,14 +29,18 @@ namespace QuantumCore.Game.World.Entities
         public IQuest? CurrentQuest { get; set; }
         public Dictionary<string, IQuest> Quests { get; } = new();
 
-        public override byte HealthPercentage {
-            get {
+        public override byte HealthPercentage
+        {
+            get
+            {
                 return 100; // todo
             }
         }
 
-        public EAntiFlags AntiFlagClass {
-            get {
+        public EAntiFlags AntiFlagClass
+        {
+            get
+            {
                 switch (Player.PlayerClass)
                 {
                     case 0:
@@ -56,8 +61,10 @@ namespace QuantumCore.Game.World.Entities
             }
         }
 
-        public EAntiFlags AntiFlagGender {
-            get {
+        public EAntiFlags AntiFlagGender
+        {
+            get
+            {
                 switch (Player.PlayerClass)
                 {
                     case 0:
@@ -92,11 +99,13 @@ namespace QuantumCore.Game.World.Entities
         private readonly ICacheManager _cacheManager;
         private readonly IWorld _world;
         private readonly ILogger<PlayerEntity> _logger;
+        private readonly IServiceScope _scope;
 
-        public PlayerEntity(PlayerData player, IGameConnection connection, IItemManager itemManager, IJobManager jobManager,
+        public PlayerEntity(PlayerData player, IGameConnection connection, IItemManager itemManager,
+            IJobManager jobManager,
             IExperienceManager experienceManager, IAnimationManager animationManager,
             IQuestManager questManager, ICacheManager cacheManager, IWorld world, ILogger<PlayerEntity> logger,
-            IItemRepository itemRepository)
+            IServiceProvider serviceProvider)
             : base(animationManager, world.GenerateVid())
         {
             Connection = connection;
@@ -107,8 +116,11 @@ namespace QuantumCore.Game.World.Entities
             _cacheManager = cacheManager;
             _world = world;
             _logger = logger;
+            _scope = serviceProvider.CreateScope();
+            var itemRepository = _scope.ServiceProvider.GetRequiredService<IItemRepository>();
             Inventory = new Inventory(itemManager, _cacheManager, _logger, itemRepository, player.Id,
-                (byte)WindowType.Inventory, InventoryConstants.DEFAULT_INVENTORY_WIDTH, InventoryConstants.DEFAULT_INVENTORY_HEIGHT, InventoryConstants.DEFAULT_INVENTORY_PAGES);
+                (byte) WindowType.Inventory, InventoryConstants.DEFAULT_INVENTORY_WIDTH,
+                InventoryConstants.DEFAULT_INVENTORY_HEIGHT, InventoryConstants.DEFAULT_INVENTORY_PAGES);
             Inventory.OnSlotChanged += Inventory_OnSlotChanged;
             Player = player;
             Empire = player.Empire;
@@ -129,6 +141,7 @@ namespace QuantumCore.Game.World.Entities
             {
                 return 0;
             }
+
             return info.StartSp + info.SpPerIq * point + info.SpPerLevel * level;
         }
 
@@ -154,7 +167,7 @@ namespace QuantumCore.Game.World.Entities
 
             CalculateDefence();
         }
-        
+
         public async Task ReloadPermissions()
         {
             Groups.Clear();
@@ -163,12 +176,12 @@ namespace QuantumCore.Game.World.Entities
 
         private async Task LoadPermGroups()
         {
+            var commandPermissionRepository = _scope.ServiceProvider.GetRequiredService<ICommandPermissionRepository>();
             var playerId = Player.Id;
 
-            var playerKey = "perm:" + playerId;
-            var list = _cacheManager.CreateList<Guid>(playerKey);
+            var groups = await commandPermissionRepository.GetGroupsForPlayer(playerId);
 
-            foreach (var group in await list.Range(0, -1))
+            foreach (var group in groups)
             {
                 Groups.Add(group);
             }
@@ -196,7 +209,8 @@ namespace QuantumCore.Game.World.Entities
 
             Persist().Wait(); // TODO
             _logger.LogInformation("Warp!");
-            var packet = new Warp {
+            var packet = new Warp
+            {
                 PositionX = PositionX,
                 PositionY = PositionY,
                 ServerAddress = IpUtils.ConvertIpToUInt(host.Ip),
@@ -225,7 +239,7 @@ namespace QuantumCore.Game.World.Entities
 
         private void CalculateDefence()
         {
-            _defence = GetPoint(EPoints.Level) + (uint)Math.Floor(0.8 * GetPoint(EPoints.Ht));
+            _defence = GetPoint(EPoints.Level) + (uint) Math.Floor(0.8 * GetPoint(EPoints.Ht));
 
             foreach (var slot in Enum.GetValues<EquipmentSlots>())
             {
@@ -234,7 +248,7 @@ namespace QuantumCore.Game.World.Entities
                 var proto = _itemManager.GetItem(item.ItemId);
                 if (proto?.Type != (byte) EItemType.Armor) continue;
 
-                _defence += (uint)proto.Values[1] + (uint)proto.Values[5] * 2;
+                _defence += (uint) proto.Values[1] + (uint) proto.Values[5] * 2;
             }
 
             _logger.LogDebug("Calculate defence value for {Name}, result: {Defence}", Name, _defence);
@@ -251,7 +265,7 @@ namespace QuantumCore.Game.World.Entities
 
             base.Die();
 
-            var dead = new CharacterDead { Vid = Vid };
+            var dead = new CharacterDead {Vid = Vid};
             foreach (var entity in NearbyEntities)
             {
                 if (entity is PlayerEntity player)
@@ -259,6 +273,7 @@ namespace QuantumCore.Game.World.Entities
                     player.Connection.Send(dead);
                 }
             }
+
             Connection.Send(dead);
         }
 
@@ -279,7 +294,7 @@ namespace QuantumCore.Game.World.Entities
             SendChatCommand("CloseRestartWindow");
             Connection.SetPhase(EPhases.Game);
 
-            var remove = new RemoveCharacter { Vid = Vid };
+            var remove = new RemoveCharacter {Vid = Vid};
 
             Connection.Send(remove);
             ShowEntity(Connection);
@@ -302,7 +317,8 @@ namespace QuantumCore.Game.World.Entities
         private void GiveStatusPoints()
         {
             var shouldHavePoints = (uint) ((Player.Level - 1) * 3);
-            var steps = (byte) Math.Floor(GetPoint(EPoints.Experience) / (double)GetPoint(EPoints.NeededExperience) * 4);
+            var steps = (byte) Math.Floor(
+                GetPoint(EPoints.Experience) / (double) GetPoint(EPoints.NeededExperience) * 4);
             shouldHavePoints += steps;
 
             if (shouldHavePoints <= Player.GivenStatusPoints)
@@ -389,6 +405,7 @@ namespace QuantumCore.Game.World.Entities
                     _healthRegenTime += HealthRegenInterval;
                 }
             }
+
             var maxSp = GetPoint(EPoints.MaxSp);
             if (Mana < maxSp)
             {
@@ -403,7 +420,7 @@ namespace QuantumCore.Game.World.Entities
                 }
             }
 
-            _persistTime += (int)elapsedTime;
+            _persistTime += (int) elapsedTime;
             if (_persistTime > PersistInterval)
             {
                 Persist().Wait(); // TODO
@@ -453,7 +470,7 @@ namespace QuantumCore.Game.World.Entities
             switch (point)
             {
                 case EPoints.Level:
-                    Player.Level = (byte)(Player.Level + value);
+                    Player.Level = (byte) (Player.Level + value);
                     foreach (var entity in NearbyEntities)
                     {
                         if (entity is IPlayerEntity other)
@@ -461,14 +478,16 @@ namespace QuantumCore.Game.World.Entities
                             SendCharacterAdditional(other.Connection);
                         }
                     }
+
                     GiveStatusPoints();
                     break;
                 case EPoints.Experience:
-                    if (_experienceManager.GetNeededExperience((byte)GetPoint(EPoints.Level)) == 0)
+                    if (_experienceManager.GetNeededExperience((byte) GetPoint(EPoints.Level)) == 0)
                     {
                         // we cannot add experience if no level up is possible
                         return;
                     }
+
                     if (value < 0 && Player.Experience <= -value)
                     {
                         Player.Experience = 0;
@@ -553,6 +572,7 @@ namespace QuantumCore.Game.World.Entities
                             SendCharacterAdditional(other.Connection);
                         }
                     }
+
                     GiveStatusPoints();
                     break;
                 case EPoints.Experience:
@@ -584,6 +604,7 @@ namespace QuantumCore.Game.World.Entities
                         Player.MinWeaponDamage = 0;
                         Player.MaxWeaponDamage = 0;
                     }
+
                     break;
             }
         }
@@ -686,6 +707,7 @@ namespace QuantumCore.Game.World.Entities
                         item.ItemId, item.Id);
                     return;
                 }
+
                 item = _itemManager.CreateItem(proto, count);
             }
 
@@ -733,11 +755,12 @@ namespace QuantumCore.Game.World.Entities
                 return; // We can't drop more gold than we have ^^
             }
 
-            AddPoint(EPoints.Gold, -(int)amount);
+            AddPoint(EPoints.Gold, -(int) amount);
             SendPoints();
 
             var item = _itemManager.CreateItem(proto, 1); // count will be overwritten as it's gold
-            (Map as Map)?.AddGroundItem(item, PositionX, PositionY, amount); // todo add method to IMap interface when we have an item interface...
+            (Map as Map)?.AddGroundItem(item, PositionX, PositionY,
+                amount); // todo add method to IMap interface when we have an item interface...
         }
 
         public override void OnDespawn()
@@ -890,6 +913,7 @@ namespace QuantumCore.Game.World.Entities
                         // Inventory
                         Inventory.PlaceItem(item, position);
                     }
+
                     break;
             }
         }
@@ -929,6 +953,7 @@ namespace QuantumCore.Game.World.Entities
             {
                 points.Points[i] = GetPoint((EPoints) i);
             }
+
             Connection.Send(points);
         }
 
@@ -946,9 +971,10 @@ namespace QuantumCore.Game.World.Entities
         {
             Debug.Assert(item.PlayerId == Player.Id);
 
-            var p = new SetItem {
+            var p = new SetItem
+            {
                 Window = item.Window,
-                Position = (ushort)item.Position,
+                Position = (ushort) item.Position,
                 ItemId = item.ItemId,
                 Count = item.Count
             };
@@ -957,7 +983,8 @@ namespace QuantumCore.Game.World.Entities
 
         public void SendRemoveItem(byte window, ushort position)
         {
-            Connection.Send(new SetItem {
+            Connection.Send(new SetItem
+            {
                 Window = window,
                 Position = position,
                 ItemId = 0,
@@ -988,20 +1015,23 @@ namespace QuantumCore.Game.World.Entities
                 Name = Player.Name,
                 Empire = Player.Empire,
                 Level = Player.Level,
-                Parts = new ushort[] {
-                    (ushort)(Inventory.EquipmentWindow.Body?.ItemId ?? 0),
-                    (ushort)(Inventory.EquipmentWindow.Weapon?.ItemId ?? 0),
+                Parts = new ushort[]
+                {
+                    (ushort) (Inventory.EquipmentWindow.Body?.ItemId ?? 0),
+                    (ushort) (Inventory.EquipmentWindow.Weapon?.ItemId ?? 0),
                     0,
-                    (ushort)(Inventory.EquipmentWindow.Hair?.ItemId ?? 0)
+                    (ushort) (Inventory.EquipmentWindow.Hair?.ItemId ?? 0)
                 }
             });
         }
 
         public void SendCharacterUpdate()
         {
-            var packet = new CharacterUpdate {
+            var packet = new CharacterUpdate
+            {
                 Vid = Vid,
-                Parts = new ushort[] {
+                Parts = new ushort[]
+                {
                     (ushort) (Inventory.EquipmentWindow.Body?.ItemId ?? 0),
                     (ushort) (Inventory.EquipmentWindow.Weapon?.ItemId ?? 0), 0,
                     (ushort) (Inventory.EquipmentWindow.Hair?.ItemId ?? 0)
@@ -1065,6 +1095,7 @@ namespace QuantumCore.Game.World.Entities
                 packet.TargetVid = Target.Vid;
                 packet.Percentage = Target.HealthPercentage;
             }
+
             Connection.Send(packet);
         }
 
@@ -1077,6 +1108,11 @@ namespace QuantumCore.Game.World.Entities
         public override string ToString()
         {
             return Player.Name + "(Player)";
+        }
+
+        public void Dispose()
+        {
+            _scope.Dispose();
         }
     }
 }

--- a/src/Executables/Game/World/Map.cs
+++ b/src/Executables/Game/World/Map.cs
@@ -66,7 +66,8 @@ namespace QuantumCore.Game.World
 
         public async Task Initialize()
         {
-            _logger.LogDebug("Load map {Name} at {PositionX}|{PositionY} (size {Width}x{Height})", Name, PositionX, PositionY, Width, Height);
+            _logger.LogDebug("Load map {Name} at {PositionX}|{PositionY} (size {Width}x{Height})", Name, PositionX,
+                PositionY, Width, Height);
 
             await _cacheManager.Set($"maps:{Name}", $"{IpUtils.PublicIP}:{_options.Port}");
             await _cacheManager.Publish("maps", $"{Name} {IpUtils.PublicIP}:{_options.Port}");
@@ -76,9 +77,9 @@ namespace QuantumCore.Game.World
             _logger.LogDebug("Loaded {SpawnPointsCount} spawn points for map {MapName}", _spawnPoints.Count, Name);
 
             // Populate map
-            foreach(var spawnPoint in _spawnPoints)
+            foreach (var spawnPoint in _spawnPoints)
             {
-                var monsterGroup = new MonsterGroup { SpawnPoint = spawnPoint };
+                var monsterGroup = new MonsterGroup {SpawnPoint = spawnPoint};
                 SpawnGroup(monsterGroup);
             }
         }
@@ -117,6 +118,10 @@ namespace QuantumCore.Game.World
                 _entities.Remove(entity);
 
                 entity.OnDespawn();
+                if (entity is IDisposable dis)
+                {
+                    dis.Dispose();
+                }
 
                 // Remove this entity from all nearby entities
                 foreach (var e in entity.NearbyEntities)
@@ -217,6 +222,7 @@ namespace QuantumCore.Game.World
                             }
                         }
                     }
+
                     break;
                 case ESpawnPointType.Group:
                 {
@@ -269,15 +275,18 @@ namespace QuantumCore.Game.World
             {
                 baseX += RandomNumberGenerator.GetInt32(-spawnPoint.RangeX, spawnPoint.RangeY);
             }
+
             if (spawnPoint.RangeY != 0)
             {
                 baseY += RandomNumberGenerator.GetInt32(-spawnPoint.RangeX, spawnPoint.RangeY);
             }
 
             var monster = new MonsterEntity(_monsterManager, _animationManager, _world, _logger, id,
-                (int)(PositionX + (baseX + RandomNumberGenerator.GetInt32(-SPAWN_BASE_OFFSET, SPAWN_BASE_OFFSET)) * SPAWN_POSITION_MULTIPLIER),
-                (int)(PositionY + (baseY + RandomNumberGenerator.GetInt32(-SPAWN_BASE_OFFSET, SPAWN_BASE_OFFSET)) * SPAWN_POSITION_MULTIPLIER),
-                    RandomNumberGenerator.GetInt32(0, 360));
+                (int) (PositionX + (baseX + RandomNumberGenerator.GetInt32(-SPAWN_BASE_OFFSET, SPAWN_BASE_OFFSET)) *
+                    SPAWN_POSITION_MULTIPLIER),
+                (int) (PositionY + (baseY + RandomNumberGenerator.GetInt32(-SPAWN_BASE_OFFSET, SPAWN_BASE_OFFSET)) *
+                    SPAWN_POSITION_MULTIPLIER),
+                RandomNumberGenerator.GetInt32(0, 360));
             _world.SpawnEntity(monster);
             return monster;
         }
@@ -296,7 +305,8 @@ namespace QuantumCore.Game.World
 
         public bool IsPositionInside(int x, int y)
         {
-            return x >= PositionX && x < PositionX + Width * MapUnit && y >= PositionY && y < PositionY + Height * MapUnit;
+            return x >= PositionX && x < PositionX + Width * MapUnit && y >= PositionY &&
+                   y < PositionY + Height * MapUnit;
         }
 
         public void SpawnEntity(IEntity entity)
@@ -313,7 +323,8 @@ namespace QuantumCore.Game.World
         /// <param name="amount">Only used for gold as we have a higher limit here</param>
         public void AddGroundItem(ItemInstance item, int x, int y, uint amount = 0)
         {
-            var groundItem = new GroundItem(_animationManager, _world.GenerateVid(), item, amount) {
+            var groundItem = new GroundItem(_animationManager, _world.GenerateVid(), item, amount)
+            {
                 PositionX = x,
                 PositionY = y
             };

--- a/src/Tests/Core.Tests/CommandTests.cs
+++ b/src/Tests/Core.Tests/CommandTests.cs
@@ -134,7 +134,12 @@ public class CommandTests : IAsyncLifetime
             .Replace(new ServiceDescriptor(typeof(IItemRepository), _ => Substitute.For<IItemRepository>(),
                 ServiceLifetime.Singleton))
             .Replace(new ServiceDescriptor(typeof(ICommandPermissionRepository),
-                _ => Substitute.For<ICommandPermissionRepository>(), ServiceLifetime.Singleton))
+                _ =>
+                {
+                    var mock = Substitute.For<ICommandPermissionRepository>();
+                    mock.GetGroupsForPlayer(Arg.Any<Guid>()).Returns([PermGroup.OperatorGroup]);
+                    return mock;
+                }, ServiceLifetime.Singleton))
             .Replace(new ServiceDescriptor(typeof(IPlayerRepository), _ => Substitute.For<IPlayerRepository>(),
                 ServiceLifetime.Singleton))
             .Replace(new ServiceDescriptor(typeof(IMonsterManager), _ => monsterManagerMock, ServiceLifetime.Singleton))
@@ -590,13 +595,13 @@ public class CommandTests : IAsyncLifetime
             Message = "Permissions reloaded"
         }, cfg => cfg.Including(x => x.Message));
     }
-    
+
     [Fact]
     public async Task InGameShopCommand()
     {
         // Prepare
         _services.GetRequiredService<IOptions<GameOptions>>().Value.InGameShop = "test";
-        
+
         // Act
         await _commandManager.Handle(_connection, "/in_game_mall");
 


### PR DESCRIPTION
Relates to #106 

Permission groups may not be reloaded if they aren't in the cache. For now they are only loaded from the db (cache can be implemented later on to improve performance).

Also changed how player entities are created. Now by a dedicated `PlayerFactory` which will be installed as a singleton service so we can inject the global `IServiceProvider` into the entity so the entity can create a `IServiceScope` to create scoped services like db connections.

Also my IDE did some auto formatting