### PR TITLE
Fix LoginFailed packet structure

### DIFF
--- a/src/Executables/Auth/Packets/LoginFailed.cs
+++ b/src/Executables/Auth/Packets/LoginFailed.cs
@@ -6,10 +6,7 @@ namespace QuantumCore.Auth.Packets
     [PacketGenerator]
     public partial class LoginFailed
     {
-        [Field(0)]
-        public byte Unknown { get; set; }
-
-        [Field(1, Length = 9)]
+        [Field(0, Length = 9)]
         public string Status { get; set; } = "";
     }
 }


### PR DESCRIPTION
LoginFailed packet had an incorrect field added that would cause game clients unable to display the correct information for a failed login.

This is an example of the fix in action.
![image](https://github.com/MeikelLP/quantum-core-x/assets/1851028/e05a6848-0a5c-4920-a65f-f2a9a3541703)
