### PR TITLE
Change default logging behaviour

### DIFF
--- a/.github/workflows/dotnet-pipeline.yml
+++ b/.github/workflows/dotnet-pipeline.yml
@@ -36,9 +36,11 @@ jobs:
           sudo chmod +x generate_kaitai.sh
           ./generate_kaitai.sh
 
-      # finally tests
+      - name: Build
+        run: dotnet build --verbosity minimal src/QuantumCore.sln
+
       - name: Test
-        run: dotnet test --verbosity normal src/QuantumCore.sln
+        run: dotnet test --no-build src/QuantumCore.sln
   deploy:
     needs:
       - test

--- a/src/Core/Extensions/ServiceExtensions.cs
+++ b/src/Core/Extensions/ServiceExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using QuantumCore.API.PluginTypes;
 using QuantumCore.Networking;
 using Serilog;
+using Serilog.Events;
 using Weikio.PluginFramework.Abstractions;
 using Weikio.PluginFramework.Microsoft.DependencyInjection;
 
@@ -61,11 +62,8 @@ public static class ServiceExtensions
         var config = new LoggerConfiguration();
 
         // add minimum log level for the instances
-#if DEBUG
-        config.MinimumLevel.Verbose();
-#else
-            config.MinimumLevel.Information();
-#endif
+        config.MinimumLevel.Information()
+            .MinimumLevel.Override("Microsoft.EntityFrameworkCore.Query", LogEventLevel.Warning);
 
         // add destructuring for entities
         config.Destructure.ToMaximumDepth(4)

--- a/src/Executables/Game/appsettings.json
+++ b/src/Executables/Game/appsettings.json
@@ -2,8 +2,7 @@
     "Serilog": {
         "MinimumLevel": {
             "Override": {
-                "QuantumCore.Auth": "Warning",
-                "QuantumCore.Game": "Warning",
+                "QuantumCore.Game": "Information",
                 "QuantumCore.Game.GameServer": "Information",
                 "QuantumCore.Game.AnimationManager": "Error",
                 "QuantumCore.Networking.PacketManager": "Information",

--- a/src/Tests/Auth.Tests/Extensions/ServiceExtensions.cs
+++ b/src/Tests/Auth.Tests/Extensions/ServiceExtensions.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Serilog;
+using Serilog.Events;
+using Xunit.Abstractions;
+
+namespace Core.Tests.Extensions;
+
+public static class ServiceExtensions
+{
+    public static IServiceCollection AddQuantumCoreTestLogger(this IServiceCollection services,
+        ITestOutputHelper testOutputHelper)
+    {
+        services.AddLogging(logging =>
+        {
+            logging.ClearProviders();
+            logging.AddSerilog(new LoggerConfiguration()
+                .WriteTo.TestOutput(testOutputHelper)
+                .MinimumLevel.Override("Microsoft.EntityFrameworkCore.Query", LogEventLevel.Warning)
+                .CreateLogger());
+        });
+        return services;
+    }
+}

--- a/src/Tests/Auth.Tests/Extensions/ServiceExtensions.cs
+++ b/src/Tests/Auth.Tests/Extensions/ServiceExtensions.cs
@@ -4,7 +4,7 @@ using Serilog;
 using Serilog.Events;
 using Xunit.Abstractions;
 
-namespace Core.Tests.Extensions;
+namespace Auth.Tests.Extensions;
 
 public static class ServiceExtensions
 {

--- a/src/Tests/Auth.Tests/MigrateTests.cs
+++ b/src/Tests/Auth.Tests/MigrateTests.cs
@@ -1,11 +1,10 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using Core.Tests.Extensions;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using QuantumCore;
 using QuantumCore.Auth.Persistence;
 using QuantumCore.Auth.Persistence.Extensions;
-using Serilog;
 using Testcontainers.MySql;
 using Testcontainers.PostgreSql;
 using Xunit;
@@ -59,15 +58,7 @@ public class MigrateTests
     private async Task ExecuteMigrate(DatabaseProvider provider, string connectionString)
     {
         var services = new ServiceCollection()
-            .AddLogging(cfg =>
-            {
-                cfg.ClearProviders();
-                cfg.AddSerilog(new LoggerConfiguration()
-                    .WriteTo.TestOutput(_testOutputHelper)
-                    .WriteTo.Console()
-                    .MinimumLevel.Debug()
-                    .CreateLogger());
-            })
+            .AddQuantumCoreTestLogger(_testOutputHelper)
             .AddSingleton<IConfiguration>(_ => new ConfigurationBuilder().Build())
             .AddAuthDatabase()
             .Configure<DatabaseOptions>(opts =>

--- a/src/Tests/Auth.Tests/MigrateTests.cs
+++ b/src/Tests/Auth.Tests/MigrateTests.cs
@@ -1,4 +1,4 @@
-﻿using Core.Tests.Extensions;
+﻿using Auth.Tests.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Tests/Core.Tests/CommandTests.cs
+++ b/src/Tests/Core.Tests/CommandTests.cs
@@ -1,11 +1,11 @@
 using AutoBogus;
 using Bogus;
+using Core.Tests.Extensions;
 using FluentAssertions;
 using FluentAssertions.Equivalency;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using QuantumCore.API;
@@ -26,7 +26,6 @@ using QuantumCore.Game.PlayerUtils;
 using QuantumCore.Game.World;
 using QuantumCore.Game.World.Entities;
 using QuantumCore.Networking;
-using Serilog;
 using Weikio.PluginFramework.Catalogs;
 using Xunit;
 using Xunit.Abstractions;
@@ -124,13 +123,7 @@ public class CommandTests : IAsyncLifetime
         _services = new ServiceCollection()
             .AddCoreServices(new EmptyPluginCatalog(), new ConfigurationBuilder().Build())
             .AddGameServices()
-            .AddLogging(x =>
-            {
-                x.ClearProviders();
-                x.AddSerilog(new LoggerConfiguration()
-                    .WriteTo.TestOutput(testOutputHelper)
-                    .CreateLogger());
-            })
+            .AddQuantumCoreTestLogger(testOutputHelper)
             .Replace(new ServiceDescriptor(typeof(IItemRepository), _ => Substitute.For<IItemRepository>(),
                 ServiceLifetime.Singleton))
             .Replace(new ServiceDescriptor(typeof(ICommandPermissionRepository),

--- a/src/Tests/Core.Tests/Extensions/ServiceExtensions.cs
+++ b/src/Tests/Core.Tests/Extensions/ServiceExtensions.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Serilog;
+using Serilog.Events;
+using Xunit.Abstractions;
+
+namespace Core.Tests.Extensions;
+
+public static class ServiceExtensions
+{
+    public static IServiceCollection AddQuantumCoreTestLogger(this IServiceCollection services,
+        ITestOutputHelper testOutputHelper)
+    {
+        services.AddLogging(logging =>
+        {
+            logging.ClearProviders();
+            logging.AddSerilog(new LoggerConfiguration()
+                .WriteTo.TestOutput(testOutputHelper)
+                .MinimumLevel.Override("Microsoft.EntityFrameworkCore.Query", LogEventLevel.Warning)
+                .CreateLogger());
+        });
+        return services;
+    }
+}

--- a/src/Tests/Core.Tests/IncomingPacketTests.cs
+++ b/src/Tests/Core.Tests/IncomingPacketTests.cs
@@ -1,11 +1,9 @@
-﻿using System;
-using System.Linq;
-using System.Text;
+﻿using System.Text;
 using AutoBogus;
+using Core.Tests.Extensions;
 using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using QuantumCore.Core.Packets;
 using QuantumCore.Extensions;
 using QuantumCore.Game.Packets;
@@ -13,7 +11,6 @@ using QuantumCore.Game.Packets.Quest;
 using QuantumCore.Game.Packets.QuickBar;
 using QuantumCore.Game.Packets.Shop;
 using QuantumCore.Networking;
-using Serilog;
 using Weikio.PluginFramework.Catalogs;
 using Xunit;
 using Xunit.Abstractions;
@@ -30,13 +27,7 @@ public class IncomingPacketTests
         var services = new ServiceCollection()
             .AddCoreServices(new EmptyPluginCatalog(), new ConfigurationBuilder().Build())
             .AddSingleton<IPacketSerializer, DefaultPacketSerializer>()
-            .AddLogging(x =>
-            {
-                x.ClearProviders();
-                x.AddSerilog(new LoggerConfiguration()
-                    .WriteTo.TestOutput(testOutputHelper)
-                    .CreateLogger());
-            })
+            .AddQuantumCoreTestLogger(testOutputHelper)
             .BuildServiceProvider();
 
         _serializer = services.GetRequiredService<IPacketSerializer>();
@@ -74,10 +65,11 @@ public class IncomingPacketTests
     {
         var expected = new AutoFaker<ChatIncoming>().Generate();
         var bytes = Array.Empty<byte>()
-            .Concat(BitConverter.GetBytes((ushort)(expected.Size + 1 + 3))) // size includes all package size + 0 terminating byte at end of string
-            .Append((byte)expected.MessageType)
+            .Concat(BitConverter.GetBytes((ushort) (expected.Size + 1 +
+                                                    3))) // size includes all package size + 0 terminating byte at end of string
+            .Append((byte) expected.MessageType)
             .Concat(Encoding.ASCII.GetBytes(expected.Message))
-            .Append((byte)0) // null byte for end of message
+            .Append((byte) 0) // null byte for end of message
             .ToArray();
 
         var result = _serializer.Deserialize<ChatIncoming>(bytes);
@@ -162,7 +154,7 @@ public class IncomingPacketTests
         // var expected = new AutoFaker<EnterGame>().Generate();
         var bytes = Array.Empty<byte>()
             .ToArray();
-        var result =  _serializer.Deserialize<EnterGame>(bytes);
+        var result = _serializer.Deserialize<EnterGame>(bytes);
 
         var ex = Assert.Throws<InvalidOperationException>(() => result.Should().BeEquivalentTo(new EnterGame()));
         ex.Message.Should()
@@ -294,7 +286,7 @@ public class IncomingPacketTests
     {
         // var expected = new AutoFaker<ShopClose>().Generate();
         var bytes = Array.Empty<byte>()
-            .Append((byte)0x00)
+            .Append((byte) 0x00)
             .ToArray();
         var result = _serializer.Deserialize<ShopClose>(bytes);
 

--- a/src/Tests/Core.Tests/MapTests.cs
+++ b/src/Tests/Core.Tests/MapTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using Core.Tests.Extensions;
 using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,7 +13,6 @@ using QuantumCore.Caching;
 using QuantumCore.Game.Services;
 using QuantumCore.Game.World;
 using QuantumCore.Game.World.Entities;
-using Serilog;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -53,7 +50,7 @@ public class MapTests
             .AddSingleton<IAtlasProvider>(_ =>
             {
                 var mock = Substitute.For<IAtlasProvider>();
-                mock.GetAsync(Arg.Any<IWorld>()).Returns(_ => new[] { _map }!);
+                mock.GetAsync(Arg.Any<IWorld>()).Returns(_ => new[] {_map}!);
                 return mock;
             })
             .AddSingleton<IConfiguration>(_ => new ConfigurationBuilder().Build())
@@ -69,19 +66,20 @@ public class MapTests
                         Leader = 101,
                         Members =
                         {
-                            new SpawnMember{Id = 101},
-                            new SpawnMember{Id = 101}
+                            new SpawnMember {Id = 101},
+                            new SpawnMember {Id = 101}
                         }
                     }
                 });
-                mock.GetSpawnGroupCollectionsAsync().Returns(_ => new []
+                mock.GetSpawnGroupCollectionsAsync().Returns(_ => new[]
                 {
                     // equal items but only one will be spawned
                     new SpawnGroupCollection
                     {
                         Id = 101,
                         Name = "TestGroupCollection",
-                        Groups = {
+                        Groups =
+                        {
                             new SpawnGroupCollectionMember
                             {
                                 Id = 101, Amount = 1
@@ -92,7 +90,8 @@ public class MapTests
                     {
                         Id = 101,
                         Name = "TestGroupCollection",
-                        Groups = {
+                        Groups =
+                        {
                             new SpawnGroupCollectionMember
                             {
                                 Id = 101, Amount = 1
@@ -110,11 +109,7 @@ public class MapTests
                 return mock;
             })
             .AddOptions<HostingOptions>().Services
-            .AddLogging(x =>
-            {
-                x.ClearProviders();
-                x.AddSerilog(new LoggerConfiguration().WriteTo.TestOutput(testOutputHelper).CreateLogger());
-            })
+            .AddQuantumCoreTestLogger(testOutputHelper)
             .BuildServiceProvider();
         var monsterManager = provider.GetRequiredService<IMonsterManager>();
         var animationManager = provider.GetRequiredService<IAnimationManager>();

--- a/src/Tests/Core.Tests/OutgoingPacketTests.cs
+++ b/src/Tests/Core.Tests/OutgoingPacketTests.cs
@@ -3,10 +3,10 @@ using System.Linq;
 using System.Text;
 using AutoBogus;
 using Bogus;
+using Core.Tests.Extensions;
 using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using QuantumCore.Extensions;
 using QuantumCore.Game.Packets;
 using QuantumCore.Game.Packets.General;
@@ -14,7 +14,6 @@ using QuantumCore.Game.Packets.Quest;
 using QuantumCore.Game.Packets.QuickBar;
 using QuantumCore.Game.Packets.Shop;
 using QuantumCore.Networking;
-using Serilog;
 using Weikio.PluginFramework.Catalogs;
 using Xunit;
 using Xunit.Abstractions;
@@ -30,13 +29,7 @@ public class OutgoingPacketTests
         var services = new ServiceCollection()
             .AddCoreServices(new EmptyPluginCatalog(), new ConfigurationBuilder().Build())
             .AddSingleton<IPacketSerializer, DefaultPacketSerializer>()
-            .AddLogging(x =>
-            {
-                x.ClearProviders();
-                x.AddSerilog(new LoggerConfiguration()
-                    .WriteTo.TestOutput(testOutputHelper)
-                    .CreateLogger());
-            })
+            .AddQuantumCoreTestLogger(testOutputHelper)
             .BuildServiceProvider();
         _serializer = services.GetRequiredService<IPacketSerializer>();
     }


### PR DESCRIPTION
_based on my work in #125_

* Logs are now less verbose by default to reduce noise
* Build pipeline is split into build + test steps. Thus it's much easier to find the broken tests
* Remove some unused config from default `appsettings.json`