### PR TITLE
Implement empire start coordinates on character creation

### DIFF
--- a/src/Core/Core/Utils/Coordinate.cs
+++ b/src/Core/Core/Utils/Coordinate.cs
@@ -1,0 +1,3 @@
+﻿namespace QuantumCore.Core.Utils;
+
+public record Coordinate(int X, int Y);

--- a/src/Executables/Game/Extensions/ConfigurationExtensions.cs
+++ b/src/Executables/Game/Extensions/ConfigurationExtensions.cs
@@ -6,6 +6,18 @@ public static class ConfigurationExtensions
 {
     public static void AddQuantumCoreDefaults(this IConfigurationBuilder config)
     {
+        // Empire Start Locations
+        config.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            {"empire:0:x", "475000"}, // Red
+            {"empire:0:y", "966100"},
+            {"empire:1:x", "60000"}, // Yellow
+            {"empire:1:y", "156000"},
+            {"empire:2:x", "963400"}, // Blue
+            {"empire:2:y", "278200"},
+        });
+        
+        // Character Stats
         config.AddInMemoryCollection(new Dictionary<string, string?>
         {
             {"job:0:Id", "0"},

--- a/src/Executables/Game/PacketHandlers/TokenLoginHandler.cs
+++ b/src/Executables/Game/PacketHandlers/TokenLoginHandler.cs
@@ -80,7 +80,7 @@ namespace QuantumCore.Game.PacketHandlers
             }
 
             // When there are no characters belonging to the account, the empire status is stored in the cache.
-            byte empire = 0;
+            byte empire = 1;
             if (charactersFromCacheOrDb.Length > 0)
             {
                 empire = charactersFromCacheOrDb[0].Empire;

--- a/src/Tests/Core.Tests/CommandTests.cs
+++ b/src/Tests/Core.Tests/CommandTests.cs
@@ -145,7 +145,13 @@ public class CommandTests : IAsyncLifetime
                 .AddInMemoryCollection(new Dictionary<string, string?>
                 {
                     {"maps:0", "map_a2"},
-                    {"maps:1", "map_b2"}
+                    {"maps:1", "map_b2"},
+                    {"empire:0:x", "10"},
+                    {"empire:0:y", "15"},
+                    {"empire:1:x", "20"},
+                    {"empire:1:y", "25"},
+                    {"empire:2:x", "30"},
+                    {"empire:2:y", "35"},
                 })
                 .Build())
             .AddSingleton(Substitute.For<IDbPlayerRepository>())


### PR DESCRIPTION
Fix invalid empire when no characters are created. 
This was causing game clients to go trough empire selection screen twice when logging in for the first time.
