### PR TITLE
Implement empire start coordinates on character creation

### DIFF
--- a/src/Core/Core/Utils/Coordinate.cs
+++ b/src/Core/Core/Utils/Coordinate.cs
@@ -1,0 +1,3 @@
+﻿namespace QuantumCore.Core.Utils;
+
+public record Coordinate(int X, int Y);

--- a/src/Core/Core/Utils/Coordinate.cs
+++ b/src/Core/Core/Utils/Coordinate.cs
@@ -1,3 +1,0 @@
-﻿namespace QuantumCore.Core.Utils;
-
-public record Coordinate(int X, int Y);

--- a/src/Executables/Game/Extensions/ConfigurationExtensions.cs
+++ b/src/Executables/Game/Extensions/ConfigurationExtensions.cs
@@ -6,6 +6,18 @@ public static class ConfigurationExtensions
 {
     public static void AddQuantumCoreDefaults(this IConfigurationBuilder config)
     {
+        // Empire Start Locations
+        config.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            {"empire:0:x", "475000"}, // Red
+            {"empire:0:y", "966100"},
+            {"empire:1:x", "60000"}, // Yellow
+            {"empire:1:y", "156000"},
+            {"empire:2:x", "963400"}, // Blue
+            {"empire:2:y", "278200"},
+        });
+        
+        // Character Stats
         config.AddInMemoryCollection(new Dictionary<string, string?>
         {
             {"job:0:Id", "0"},

--- a/src/Executables/Game/Extensions/ConfigurationExtensions.cs
+++ b/src/Executables/Game/Extensions/ConfigurationExtensions.cs
@@ -9,12 +9,14 @@ public static class ConfigurationExtensions
         // Empire Start Locations
         config.AddInMemoryCollection(new Dictionary<string, string?>
         {
-            {"empire:0:x", "475000"}, // Red
-            {"empire:0:y", "966100"},
-            {"empire:1:x", "60000"}, // Yellow
-            {"empire:1:y", "156000"},
-            {"empire:2:x", "963400"}, // Blue
-            {"empire:2:y", "278200"},
+            {"game:empire:0:x", "0"},        // Ignored
+            {"game:empire:0:y", "0"},
+            {"game:empire:1:x", "475000"},   // Red
+            {"game:empire:1:y", "966100"},
+            {"game:empire:2:x", "60000"},    // Yellow
+            {"game:empire:2:y", "156000"},
+            {"game:empire:3:x", "963400"},   // Blue
+            {"game:empire:3:y", "278200"},
         });
         
         // Character Stats

--- a/src/Executables/Game/Extensions/GameOptions.cs
+++ b/src/Executables/Game/Extensions/GameOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace QuantumCore.Game.Extensions;
+﻿using System.Drawing;
+
+namespace QuantumCore.Game.Extensions;
 
 public class GameOptions
 {
@@ -6,4 +8,10 @@ public class GameOptions
     /// Contains the in-game shop webpage address
     /// </summary>
     public string InGameShop { get; set; } = "https://example.com/";
+
+    /// <summary>
+    /// Contains the starting locations for each empire.
+    /// <remarks>Index 0 will always contain a invalid empire coordinates</remarks>
+    /// </summary>
+    public IReadOnlyList<Point> Empire { get; set; } = new List<Point>();
 }

--- a/src/Executables/Game/PacketHandlers/TokenLoginHandler.cs
+++ b/src/Executables/Game/PacketHandlers/TokenLoginHandler.cs
@@ -80,7 +80,7 @@ namespace QuantumCore.Game.PacketHandlers
             }
 
             // When there are no characters belonging to the account, the empire status is stored in the cache.
-            byte empire = 0;
+            byte empire = 1;
             if (charactersFromCacheOrDb.Length > 0)
             {
                 empire = charactersFromCacheOrDb[0].Empire;

--- a/src/Executables/Game/PlayerManager.cs
+++ b/src/Executables/Game/PlayerManager.cs
@@ -1,8 +1,11 @@
-﻿using Game.Caching;
+﻿using System.Drawing;
+using Game.Caching;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using QuantumCore.API.Core.Models;
 using QuantumCore.Core.Utils;
+using QuantumCore.Game.Extensions;
 using QuantumCore.Game.Persistence;
 using QuantumCore.Game.PlayerUtils;
 
@@ -14,17 +17,16 @@ public class PlayerManager : IPlayerManager
     private readonly ICachePlayerRepository _cachePlayerRepository;
     private readonly ILogger<PlayerManager> _logger;
     private readonly IJobManager _jobManager;
-    private readonly IList<Coordinate> _empireStartCoordinates;
+    private readonly GameOptions _gameOptions;
     
     public PlayerManager(IDbPlayerRepository dbPlayerRepository, ICachePlayerRepository cachePlayerRepository,
-        ILogger<PlayerManager> logger, IJobManager jobManager, IConfiguration configuration)
+        ILogger<PlayerManager> logger, IJobManager jobManager, IOptions<GameOptions> gameOptions)
     {
         _dbPlayerRepository = dbPlayerRepository;
         _cachePlayerRepository = cachePlayerRepository;
         _logger = logger;
         _jobManager = jobManager;
-        _empireStartCoordinates = configuration.GetSection("empire").Get<List<Coordinate>>() ?? 
-                                  throw new InvalidOperationException("Could not load empire start coordinates");
+        _gameOptions = gameOptions.Value;
     }
 
     public async Task<PlayerData?> GetPlayer(Guid accountId, byte slot)
@@ -130,8 +132,8 @@ public class PlayerManager : IPlayerManager
             AccountId = accountId,
             Name = playerName,
             PlayerClass = @class,
-            PositionX = _empireStartCoordinates[empire - 1].X,
-            PositionY = _empireStartCoordinates[empire - 1].Y,
+            PositionX = _gameOptions.Empire[empire].X,
+            PositionY = _gameOptions.Empire[empire].Y,
             St = job.St,
             Iq = job.Iq,
             Dx = job.Dx,

--- a/src/Tests/Core.Tests/CommandTests.cs
+++ b/src/Tests/Core.Tests/CommandTests.cs
@@ -145,7 +145,13 @@ public class CommandTests : IAsyncLifetime
                 .AddInMemoryCollection(new Dictionary<string, string?>
                 {
                     {"maps:0", "map_a2"},
-                    {"maps:1", "map_b2"}
+                    {"maps:1", "map_b2"},
+                    {"empire:0:x", "10"},
+                    {"empire:0:y", "15"},
+                    {"empire:1:x", "20"},
+                    {"empire:1:y", "25"},
+                    {"empire:2:x", "30"},
+                    {"empire:2:y", "35"},
                 })
                 .Build())
             .AddSingleton(Substitute.For<IDbPlayerRepository>())


### PR DESCRIPTION
Fix invalid empire when no characters are created. This was causing game clients to go trough empire selection screen twice.
