### PR TITLE
Implement option to define command alias

### DIFF
--- a/src/CorePluginAPI/Game/Command.cs
+++ b/src/CorePluginAPI/Game/Command.cs
@@ -1,6 +1,6 @@
 ﻿namespace QuantumCore.API.Game
 {
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     public class CommandAttribute : Attribute
     {
         public CommandAttribute(string name, string description)
@@ -8,17 +8,9 @@
             Name = name;
             Description = description;
         }
-        
-        public CommandAttribute(string name, string description, params string[] alias)
-        {
-            Name = name;
-            Description = description;
-            Alias = alias.ToList();
-        }
 
         public string Name { get; }
         public string Description { get; }
-        public List<string> Alias { get; set; } = [];
     }
 
     [AttributeUsage(AttributeTargets.Method)]

--- a/src/CorePluginAPI/Game/Command.cs
+++ b/src/CorePluginAPI/Game/Command.cs
@@ -8,9 +8,17 @@
             Name = name;
             Description = description;
         }
+        
+        public CommandAttribute(string name, string description, params string[] alias)
+        {
+            Name = name;
+            Description = description;
+            Alias = alias.ToList();
+        }
 
         public string Name { get; }
         public string Description { get; }
+        public List<string> Alias { get; set; } = [];
     }
 
     [AttributeUsage(AttributeTargets.Method)]

--- a/src/Executables/Game/Commands/CommandManager.cs
+++ b/src/Executables/Game/Commands/CommandManager.cs
@@ -62,6 +62,7 @@ namespace QuantumCore.Game.Commands
 
                 var cmd = cmdAttr.Name;
                 var desc = cmdAttr.Description;
+                var validAlias = cmdAttr.Alias;
                 var bypass = type.GetCustomAttribute<CommandNoPermissionAttribute>() is not null;
                 Type? optionsType = null;
                 var intf = type.GetInterfaces().FirstOrDefault(x =>
@@ -72,6 +73,13 @@ namespace QuantumCore.Game.Commands
                 }
 
                 _commandHandlers.Add(cmd, new CommandDescriptor(type, cmd, desc, optionsType, bypass));
+
+                if (validAlias.Count <= 0) continue;
+                
+                foreach (var alias in validAlias)
+                {
+                    _commandHandlers.Add(alias, new CommandDescriptor(type, cmd, desc, optionsType, bypass));
+                }
             }
         }
 

--- a/src/Executables/Game/Commands/CommandManager.cs
+++ b/src/Executables/Game/Commands/CommandManager.cs
@@ -51,18 +51,32 @@ namespace QuantumCore.Game.Commands
 
             foreach (var type in types)
             {
-                var cmdAttr = type.GetCustomAttribute<CommandAttribute>();
+                var cmdAttrs = type.GetCustomAttributes<CommandAttribute>().ToList();
+                if (cmdAttrs.Count > 0)
+                {
+                    foreach (var cmdAttr in cmdAttrs)
+                    {
+                        ProcessCommandAttribute(type, cmdAttr);
+                    }
+                }
+                else
+                {
+                    _logger.LogWarning("Command {Type} does not have a CommandAttribute", type.Name);
+                }
+            }
+
+            void ProcessCommandAttribute(Type type, CommandAttribute? cmdAttr)
+            {
                 if (cmdAttr is null)
                 {
                     _logger.LogWarning(
                         "Command handler {Type} is implementing {HandlerInterface} but is missing a {AttributeName}",
                         type.Name, nameof(ICommandHandler), nameof(CommandAttribute));
-                    continue;
+                    return;
                 }
 
                 var cmd = cmdAttr.Name;
                 var desc = cmdAttr.Description;
-                var validAlias = cmdAttr.Alias;
                 var bypass = type.GetCustomAttribute<CommandNoPermissionAttribute>() is not null;
                 Type? optionsType = null;
                 var intf = type.GetInterfaces().FirstOrDefault(x =>
@@ -73,13 +87,6 @@ namespace QuantumCore.Game.Commands
                 }
 
                 _commandHandlers.Add(cmd, new CommandDescriptor(type, cmd, desc, optionsType, bypass));
-
-                if (validAlias.Count <= 0) continue;
-                
-                foreach (var alias in validAlias)
-                {
-                    _commandHandlers.Add(alias, new CommandDescriptor(type, cmd, desc, optionsType, bypass));
-                }
             }
         }
 


### PR DESCRIPTION
Some commands have multiple alias such as /a , /advance, etc
This way we can now optionally define alias for commands.

Altought alias are being used as a copy of the command itself when being registered, it provides a way to not need reflection when evaluating incoming commands at runtime.