### PR TITLE
Replace Moq with NSubstitute

### DIFF
--- a/src/Core/Extensions/ServiceExtensions.cs
+++ b/src/Core/Extensions/ServiceExtensions.cs
@@ -37,7 +37,9 @@ public static class ServiceExtensions
                             x.GetCustomAttribute<PacketAttribute>()?.Direction.HasFlag(EDirection.Incoming) == true)
                 .OrderBy(x => x.FullName)
                 .ToArray();
-            var handlerTypes = AppDomain.CurrentDomain.GetAssemblies().SelectMany(x => x.ExportedTypes)
+            var handlerTypes = AppDomain.CurrentDomain.GetAssemblies()
+                .Where(x => !x.IsDynamic)
+                .SelectMany(x => x.ExportedTypes)
                 .Where(x =>
                     x.IsAssignableTo(typeof(IPacketHandler)) &&
                     x is {IsClass: true, IsAbstract: false, IsInterface: false})

--- a/src/Game.Benchmarks/Benchmarks/WorldUpdateBenchmark.cs
+++ b/src/Game.Benchmarks/Benchmarks/WorldUpdateBenchmark.cs
@@ -1,4 +1,4 @@
-using BenchmarkDotNet.Attributes;
+﻿using BenchmarkDotNet.Attributes;
 using Core.Persistence.Extensions;
 using Game.Caching.Extensions;
 using Microsoft.Extensions.Configuration;
@@ -6,7 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Moq;
+using NSubstitute;
 using QuantumCore;
 using QuantumCore.API;
 using QuantumCore.API.Core.Models;
@@ -16,7 +16,6 @@ using QuantumCore.Caching.Extensions;
 using QuantumCore.Extensions;
 using QuantumCore.Game;
 using QuantumCore.Game.Extensions;
-using QuantumCore.Game.PlayerUtils;
 using QuantumCore.Game.Services;
 using QuantumCore.Game.World;
 using QuantumCore.Game.World.Entities;
@@ -50,35 +49,35 @@ public class WorldUpdateBenchmark
             .AddGameServices()
             .Replace(new ServiceDescriptor(typeof(IAtlasProvider), provider =>
             {
-                var mock = new Mock<IAtlasProvider>();
-                mock.Setup(x => x.GetAsync(It.IsAny<IWorld>())).ReturnsAsync<IWorld, IAtlasProvider, IEnumerable<IMap>>(
-                    world => new[]
+                var mock = Substitute.For<IAtlasProvider>();
+                mock.GetAsync(Arg.Any<IWorld>()).Returns(
+                    callInfo => new[]
                     {
                         new Map(provider.GetRequiredService<IMonsterManager>(),
                             provider.GetRequiredService<IAnimationManager>(),
-                            provider.GetRequiredService<ICacheManager>(), world,
+                            provider.GetRequiredService<ICacheManager>(), callInfo.Arg<IWorld>(),
                             provider.GetRequiredService<IOptions<HostingOptions>>(),
                             provider.GetRequiredService<ILogger<Map>>(),
-                            provider.GetRequiredService<ISpawnPointProvider>(), 
+                            provider.GetRequiredService<ISpawnPointProvider>(),
                             provider.GetRequiredService<IDropProvider>(),
                             provider.GetRequiredService<IItemManager>(),
                             "test_map", 0, 0, 1024, 1024
                         )
                     });
-                        
-                return mock.Object;
+
+                return mock;
             }, ServiceLifetime.Singleton))
             .Replace(new ServiceDescriptor(typeof(ICacheManager), _ =>
             {
-                var mock = new Mock<ICacheManager>();
-                mock.Setup(x => x.Keys("maps:*")).ReturnsAsync(new[] {"maps:test_map"});
-                mock.Setup(x => x.Subscribe()).Returns(new Mock<IRedisSubscriber>().Object);
-                return mock.Object;
+                var mock = Substitute.For<ICacheManager>();
+                mock.Keys("maps:*").Returns(new[] {"maps:test_map"});
+                mock.Subscribe().Returns(Substitute.For<IRedisSubscriber>());
+                return mock;
             }, ServiceLifetime.Singleton))
             .Replace(new ServiceDescriptor(typeof(ISpawnPointProvider), _ =>
             {
-                var mock = new Mock<ISpawnPointProvider>();
-                mock.Setup(x => x.GetSpawnPointsForMap("test_map")).ReturnsAsync(Enumerable
+                var mock = Substitute.For<ISpawnPointProvider>();
+                mock.GetSpawnPointsForMap("test_map").Returns(Enumerable
                     .Range(0, MobAmount)
                     .Select(_ =>
                         new SpawnPoint
@@ -94,22 +93,22 @@ public class WorldUpdateBenchmark
                     )
                     .ToArray()
                 );
-                return mock.Object;
+                return mock;
             }, ServiceLifetime.Singleton))
             .Replace(new ServiceDescriptor(typeof(IJobManager), _ =>
             {
-                var mock = new Mock<IJobManager>();
-                mock.Setup(x => x.Get(1)).Returns(new Job());
-                return mock.Object;
+                var mock = Substitute.For<IJobManager>();
+                mock.Get(1).Returns(new Job());
+                return mock;
             }, ServiceLifetime.Singleton))
             .Replace(new ServiceDescriptor(typeof(IMonsterManager), _ =>
             {
-                var mock = new Mock<IMonsterManager>();
-                mock.Setup(x => x.GetMonster(42)).Returns(new MonsterData
+                var mock = Substitute.For<IMonsterManager>();
+                mock.GetMonster(42).Returns(new MonsterData
                 {
                     Type = (byte) EEntityType.Monster
                 });
-                return mock.Object;
+                return mock;
             }, ServiceLifetime.Singleton))
             .BuildServiceProvider();
         _world = ActivatorUtilities.CreateInstance<World>(services);
@@ -125,8 +124,7 @@ public class WorldUpdateBenchmark
                 PositionX = 1,
                 PositionY = 1
             };
-            var connMock = new Mock<IGameConnection>();
-            var conn = connMock.Object;
+            var conn = Substitute.For<IGameConnection>();
             var entity = ActivatorUtilities.CreateInstance<PlayerEntity>(services, _world, player, conn);
             _world.SpawnEntity(entity);
         }

--- a/src/Game.Benchmarks/Game.Benchmarks.csproj
+++ b/src/Game.Benchmarks/Game.Benchmarks.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup>
       <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
-      <PackageReference Include="Moq" Version="4.18.2" />
+        <PackageReference Include="NSubstitute" Version="5.1.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Tests/Data.Auth.Tests/AccountManagerTests.cs
+++ b/src/Tests/Data.Auth.Tests/AccountManagerTests.cs
@@ -1,10 +1,10 @@
-using Data.Auth.Tests.Fixtures;
+﻿using Data.Auth.Tests.Fixtures;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 using QuantumCore;
 using QuantumCore.API;
 using QuantumCore.API.Core.Models;
@@ -116,10 +116,9 @@ public class AccountManagerTests : IClassFixture<RedisFixture>, IClassFixture<Da
     [Fact]
     public async Task CreateAccount_DuplicateUserName()
     {
-        var accountRepositoryMock = new Mock<IAccountRepository>();
-        accountRepositoryMock.Setup(x => x.FindByNameAsync("testificate"))
-            .ReturnsAsync(() => new AccountData());
-        var accountManager = new AccountManager(accountRepositoryMock.Object, _passwordHasher);
+        var accountRepositoryMock = Substitute.For<IAccountRepository>();
+        accountRepositoryMock.FindByNameAsync("testificate").Returns(new AccountData());
+        var accountManager = new AccountManager(accountRepositoryMock, _passwordHasher);
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
             accountManager.CreateAsync("testificate", "testificate", "some@gmail.com", "1234567"));
     }

--- a/src/Tests/Data.Auth.Tests/Data.Auth.Tests.csproj
+++ b/src/Tests/Data.Auth.Tests/Data.Auth.Tests.csproj
@@ -8,7 +8,7 @@
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-        <PackageReference Include="Moq" Version="4.18.2" />
+        <PackageReference Include="NSubstitute" Version="5.1.0"/>
         <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0"/>
         <PackageReference Include="Testcontainers.MySql" Version="3.8.0" />
         <PackageReference Include="Testcontainers.Redis" Version="3.8.0" />


### PR DESCRIPTION
Moq has proven as [not trustworthy in the past](https://github.com/devlooped/moq/issues/1372) thus removing it in favor of NSubstitute