### PR TITLE
fix the registration of command handlers

### DIFF
--- a/src/Executables/Game/GameServer.cs
+++ b/src/Executables/Game/GameServer.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Net;
+using System.Reflection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using QuantumCore.API;
@@ -110,7 +111,7 @@ namespace QuantumCore.Game
             await World.Load();
 
             // Register all default commands
-            _commandManager.Register("QuantumCore.Game.Commands");
+            _commandManager.Register("QuantumCore.Game.Commands", Assembly.GetExecutingAssembly());
 
             // Put all new connections into login phase
             RegisterNewConnectionListener(connection =>


### PR DESCRIPTION
The fact that **CommandManager** was moved to a new assembly resulted in the "types" list being empty here. 

![image](https://github.com/MeikelLP/quantum-core-x/assets/45075421/af32102f-c031-4bb8-aeb2-ad3bdba65bf7)
 
This happens when initializing the CommandManager from the Game assembly, where all the command handlers are.