### PR TITLE
Use correct method for the PacketOperationListener when a packet is sent

### DIFF
--- a/src/Core/Core/Networking/Connection.cs
+++ b/src/Core/Core/Networking/Connection.cs
@@ -144,7 +144,7 @@ namespace QuantumCore.Core.Networking
                             await _stream.WriteAsync(bytesToSend).ConfigureAwait(false);
                             await _stream.FlushAsync().ConfigureAwait(false);
                             await _pluginExecutor.ExecutePlugins<IPacketOperationListener>(_logger,
-                                    x => x.OnPostPacketReceivedAsync(obj, bytes, CancellationToken.None))
+                                    x => x.OnPostPacketSentAsync(obj, bytes, CancellationToken.None))
                                 .ConfigureAwait(false);
                         }
                         catch (Exception e)


### PR DESCRIPTION
Incorrect method for when a packet just finished sending was being called.
This pr fixes it by using the correct method call.