### PR TITLE
revert: remove enqueueing the monster spawn

### DIFF
--- a/src/Executables/Game/World/Map.cs
+++ b/src/Executables/Game/World/Map.cs
@@ -328,12 +328,7 @@ namespace QuantumCore.Game.World
                 monster.Rotation = RandomNumberGenerator.GetInt32(0, 360);
             }
 
-            EventSystem.EnqueueEvent(() =>
-            {
-                _world.SpawnEntity(monster);
-                return 0;
-            }, spawnPoint.RespawnTime * 1000);
-
+            _world.SpawnEntity(monster);
             return monster;
         }
 


### PR DESCRIPTION
There was a significant performance loss and some tick failures after #178 due to enqueueing every spawn. Also, this PR might cause a bulk spawn of the ores.
