### PR TITLE
feat(game): track heartbeat to ensure account connected

### DIFF
--- a/docs/docs/Metin 2/Process Flows.md
+++ b/docs/docs/Metin 2/Process Flows.md
@@ -41,3 +41,15 @@ sequenceDiagram
     C->>-S: 11 - client closes connection With auth server
     deactivate S
 ```
+
+# Heartbeat
+
+```mermaid
+sequenceDiagram
+    participant S as Game Server
+    participant C as Client
+    S->>+C: Sends Ping (0x2C) packet after handshake
+    C->>+S: Sends Pong (0x2F) packet in response
+    S-->>-C: Acknowledges with Ping (0x2C) packet
+    Note over S, C: Repeat this sequence every 5 seconds
+```

--- a/docs/docs/Metin 2/Process Flows.md
+++ b/docs/docs/Metin 2/Process Flows.md
@@ -49,7 +49,7 @@ sequenceDiagram
     participant S as Game Server
     participant C as Client
     S->>+C: Sends Ping (0x2C) packet after handshake
-    C->>+S: Sends Pong (0x2F) packet in response
+    C->>+S: Sends Pong (0xFE) packet in response
     S-->>-C: Acknowledges with Ping (0x2C) packet
     Note over S, C: Repeat this sequence every 5 seconds
 ```

--- a/src/Core.Networking/NetworkingConstants.cs
+++ b/src/Core.Networking/NetworkingConstants.cs
@@ -2,5 +2,7 @@
 
 public static class NetworkingConstants
 {
-    public static int BufferSize = 4096;
+    public static readonly int BufferSize = 4096;
+    
+    public static readonly int PingIntervalInSeconds = 5;
 }

--- a/src/Executables/Game/GameConnection.cs
+++ b/src/Executables/Game/GameConnection.cs
@@ -36,12 +36,12 @@ namespace QuantumCore.Game
         protected override void OnHandshakeFinished()
         {
             GameServer.Instance.CallConnectionListener(this);
-            
+            var pingInterval = NetworkingConstants.PingIntervalInSeconds * 1000;
             EventSystem.EnqueueEvent(() =>
             {
                 Send(new Ping());
-                return NetworkingConstants.PingIntervalInSeconds * 1000;
-            }, NetworkingConstants.PingIntervalInSeconds * 1000);
+                return pingInterval;
+            }, pingInterval);
         }
 
         protected override async Task OnClose(bool expected = true)

--- a/src/Executables/Game/GameConnection.cs
+++ b/src/Executables/Game/GameConnection.cs
@@ -37,9 +37,10 @@ namespace QuantumCore.Game
         {
             GameServer.Instance.CallConnectionListener(this);
             var pingInterval = NetworkingConstants.PingIntervalInSeconds * 1000;
+            var ping = new Ping();
             EventSystem.EnqueueEvent(() =>
             {
-                Send(new Ping());
+                Send(ping);
                 return pingInterval;
             }, pingInterval);
         }

--- a/src/Executables/Game/GameConnection.cs
+++ b/src/Executables/Game/GameConnection.cs
@@ -4,7 +4,9 @@ using QuantumCore.API;
 using QuantumCore.API.Game.Types;
 using QuantumCore.API.Game.World;
 using QuantumCore.Caching;
+using QuantumCore.Core.Event;
 using QuantumCore.Core.Networking;
+using QuantumCore.Game.Packets;
 using QuantumCore.Networking;
 
 namespace QuantumCore.Game
@@ -34,6 +36,12 @@ namespace QuantumCore.Game
         protected override void OnHandshakeFinished()
         {
             GameServer.Instance.CallConnectionListener(this);
+            
+            EventSystem.EnqueueEvent(() =>
+            {
+                Send(new Ping());
+                return NetworkingConstants.PingIntervalInSeconds * 1000;
+            }, NetworkingConstants.PingIntervalInSeconds * 1000);
         }
 
         protected override async Task OnClose(bool expected = true)
@@ -59,9 +67,8 @@ namespace QuantumCore.Game
                     }
                 }
                 
-                _cacheManager.Shared.DelAllAsync($"*{AccountId}");
-                _cacheManager.Server.DelAllAsync($"player:{Player!.Player.Id}");
                 
+                _cacheManager.Server.DelAllAsync($"player:{Player!.Player.Id}");
             }
 
             await Server.RemoveConnection(this);

--- a/src/Executables/Game/PacketHandlers/PongHandler.cs
+++ b/src/Executables/Game/PacketHandlers/PongHandler.cs
@@ -2,9 +2,7 @@
 using QuantumCore.API;
 using QuantumCore.API.PluginTypes;
 using QuantumCore.Caching;
-using QuantumCore.Core.Event;
 using QuantumCore.Game.Packets;
-using Ack = QuantumCore.Game.Packets.Ping;
 using QuantumCore.Networking;
 
 namespace QuantumCore.Game.PacketHandlers;
@@ -31,7 +29,8 @@ public class PongHandler : IGamePacketHandler<Pong>
         _cacheManager.Server.Expire($"account:{ctx.Connection.AccountId}:game:select:selected-player", expiration);
         _cacheManager.Server.Expire($"token:{activeToken}", expiration);
         
-        ctx.Connection.Send(new Ack());
+        // Send a Ping packet to acknowledge the Pong. This won't be responded to with a Pong by the client
+        ctx.Connection.Send(new Ping());
         
         return Task.CompletedTask;
     }

--- a/src/Executables/Game/PacketHandlers/PongHandler.cs
+++ b/src/Executables/Game/PacketHandlers/PongHandler.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.Extensions.Logging;
+using QuantumCore.API;
+using QuantumCore.API.PluginTypes;
+using QuantumCore.Caching;
+using QuantumCore.Core.Event;
+using QuantumCore.Game.Packets;
+using Ack = QuantumCore.Game.Packets.Ping;
+using QuantumCore.Networking;
+
+namespace QuantumCore.Game.PacketHandlers;
+
+public class PongHandler : IGamePacketHandler<Pong>
+{
+    private readonly ILogger<PongHandler> _logger;
+    private readonly ICacheManager _cacheManager;
+
+    public PongHandler(ILogger<PongHandler> logger, ICacheManager cacheManager)
+    {
+        _logger = logger;
+        _cacheManager = cacheManager;
+    }
+
+    public Task ExecuteAsync(GamePacketContext<Pong> ctx, CancellationToken token = default)
+    {
+        var expiration = TimeSpan.FromSeconds(NetworkingConstants.PingIntervalInSeconds + 1);
+        
+        _logger.LogDebug("Received pong from {Username}", ctx.Connection.AccountId);
+        var activeToken = _cacheManager.Shared.Get<Guid>($"account:token:{ctx.Connection.AccountId}");
+        
+        _cacheManager.Shared.Expire($"account:token:{ctx.Connection.AccountId}", expiration);
+        _cacheManager.Server.Expire($"account:{ctx.Connection.AccountId}:game:select:selected-player", expiration);
+        _cacheManager.Server.Expire($"token:{activeToken}", expiration);
+        
+        ctx.Connection.Send(new Ack());
+        
+        return Task.CompletedTask;
+    }
+}

--- a/src/Executables/Game/Packets/Ping.cs
+++ b/src/Executables/Game/Packets/Ping.cs
@@ -1,0 +1,10 @@
+﻿using QuantumCore.Networking;
+
+namespace QuantumCore.Game.Packets
+{
+    [Packet(0x2C, EDirection.Outgoing, Sequence = true)]
+    [PacketGenerator]
+    public partial class Ping
+    {
+    }
+}

--- a/src/Executables/Game/Packets/Pong.cs
+++ b/src/Executables/Game/Packets/Pong.cs
@@ -1,0 +1,11 @@
+﻿using QuantumCore.Networking;
+
+namespace QuantumCore.Game.Packets
+{
+    [Packet(0xFE, EDirection.Incoming, Sequence = true)]
+    [PacketGenerator]
+    public partial class Pong
+    {
+
+    }
+}

--- a/src/Executables/Game/Packets/Pong.cs
+++ b/src/Executables/Game/Packets/Pong.cs
@@ -6,6 +6,5 @@ namespace QuantumCore.Game.Packets
     [PacketGenerator]
     public partial class Pong
     {
-
     }
 }


### PR DESCRIPTION
Introduces a heartbeat system using outgoing ping (`0x2C`) and incoming pong (`0xFE`) packets.


```mermaid
sequenceDiagram
    participant S as Game Server
    participant C as Client

    S->>+C: Sends Ping (0x2C) packet after handshake
    C->>+S: Sends Pong (0xFE) packet in response
    S-->>-C: Acknowledges with Ping (0x2C) packet
    Note over S, C: Repeat this sequence every 5 seconds
```

Closes #201 