### PR TITLE
fix(game): command validation

### DIFF
--- a/docs/docs/Configuration/game.md
+++ b/docs/docs/Configuration/game.md
@@ -21,6 +21,14 @@ Section: `Game`
 |---|---|---|---|---|---|
 |`Game:InGameShop`|`string`|`https://example.com/`|`false`|`https://example.com/`|URL that will be opened when the client clicks on the item shop|
 
+## Commands
+
+Section: `Game:Commands`
+
+| Key          | Type   | Default | Required | Examples | Notes                                                                                                                                   |
+|--------------|--------|---------|----------|----------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| `StrictMode` | `bool` | `false` | `false`  | `true`   | Will throw exceptions (and maybe disconnect the player) when commands fail. Used for testing. Otherwise sends chat messages in response |
+
 ### Skills
 
 Section: `Game:Skills`

--- a/src/Executables/DocsGenerator/CommandDocsGenerator.cs
+++ b/src/Executables/DocsGenerator/CommandDocsGenerator.cs
@@ -55,6 +55,9 @@ public static class CommandDocsGenerator
             var path = Path.GetFullPath(Path.Combine(commandsDir, $"{type.Name}.md"));
             var content = new StringBuilder();
             content.AppendLine($"""
+                                ---
+                                title: /{type.Commands.First().Name}
+                                ---
                                 # {type.Name}
 
                                 ## Command

--- a/src/Libraries/Game.Commands/CommandValidationException.cs
+++ b/src/Libraries/Game.Commands/CommandValidationException.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Immutable;
+
+namespace QuantumCore.Game.Commands;
+
+public class CommandValidationException : Exception
+{
+    public string Command { get; }
+    public ImmutableArray<string> Errors { get; set; } = [];
+
+    public CommandValidationException(string command) : base("Command arguments validation failed")
+    {
+        Command = command;
+    }
+}

--- a/src/Libraries/Game.Server/Commands/AdvanceCommand.cs
+++ b/src/Libraries/Game.Server/Commands/AdvanceCommand.cs
@@ -42,5 +42,5 @@ public class AdvanceCommand : ICommandHandler<AdvanceCommandOptions>
 public class AdvanceCommandOptions
 {
     [Value(0)] public string Target { get; set; } = "$self";
-    [Value(1, Required = true)] public int Level { get; set; }
+    [Value(1)] public int Level { get; set; } = 1;
 }

--- a/src/Tests/Game.Commands.Tests/Game.Commands.Tests.csproj
+++ b/src/Tests/Game.Commands.Tests/Game.Commands.Tests.csproj
@@ -30,6 +30,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\Libraries\Game.Commands\Game.Commands.csproj"/>
+      <ProjectReference Include="..\..\Libraries\Game.Server\Game.Server.csproj"/>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Otherwise an exception would be thrown and the connection may be aborted

For example running
```
/setjob
/setjob a
```

would cause such issue.

Also

* updated how commands look in the docs
* fixed /advance command always requiring a level