### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-pipeline.yml
+++ b/.github/workflows/dotnet-pipeline.yml
@@ -13,7 +13,8 @@ env:
 
 jobs:
   test:
-
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/MeikelLP/quantum-core-x/security/code-scanning/16](https://github.com/MeikelLP/quantum-core-x/security/code-scanning/16)

To fix the issue, we will add a `permissions` block to the `test` job, explicitly setting the permissions to the least privilege required. Since the `test` job only needs to read the repository contents, we will set `contents: read`. This ensures that the job cannot perform any write operations or access other permissions unnecessarily.

The changes will be made in the `.github/workflows/dotnet-pipeline.yml` file, specifically within the `test` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
