### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gh-pages-test.yml
+++ b/.github/workflows/gh-pages-test.yml
@@ -7,6 +7,9 @@ on:
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: docs


### PR DESCRIPTION
Potential fix for [https://github.com/MeikelLP/quantum-core-x/security/code-scanning/15](https://github.com/MeikelLP/quantum-core-x/security/code-scanning/15)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily involves testing and building a website, it likely only requires `contents: read` permissions. This will restrict the `GITHUB_TOKEN` to read-only access to the repository contents, adhering to the principle of least privilege.

The `permissions` block will be added at the root level of the workflow, applying to all jobs within the workflow. This ensures consistency and avoids the need to define permissions for each job individually.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
