### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,4 +1,6 @@
 name: SonarCloud
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/MeikelLP/quantum-core-x/security/code-scanning/14](https://github.com/MeikelLP/quantum-core-x/security/code-scanning/14)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions to `contents: read`, which is sufficient for the operations performed in this workflow. This change ensures that the workflow does not have unnecessary write permissions, reducing the risk of unintended modifications to the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
