### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -16,6 +16,8 @@ jobs:
   build:
     name: Build Docusaurus
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/MeikelLP/quantum-core-x/security/code-scanning/13](https://github.com/MeikelLP/quantum-core-x/security/code-scanning/13)

To fix the issue, we will add a `permissions` block to the `build` job. Since the `build` job only involves checking out the repository, setting up dependencies, and building the project, it does not require any write permissions. The minimal permissions required are `contents: read`. This change will ensure that the `build` job operates with the least privilege necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
