### PR TITLE
feat(game): character select slot positions from DB query rownum

### DIFF
--- a/src/Data/Game.Persistence/DbPlayerRepository.cs
+++ b/src/Data/Game.Persistence/DbPlayerRepository.cs
@@ -17,11 +17,13 @@ public class DbPlayerRepository : IDbPlayerRepository
 
     public async Task<PlayerData[]> GetPlayersAsync(Guid accountId)
     {
-        return await _db.Players
-            .AsNoTracking()
-            .Where(x => x.AccountId == accountId)
-            .SelectPlayerData()
-            .ToArrayAsync();
+        return (await _db.Players
+                .AsNoTracking()
+                .Where(x => x.AccountId == accountId)
+                .OrderBy(x => x.Id) // deterministic ordering for character select slot
+                .SelectPlayerData()
+                .ToArrayAsync())
+            .AssignIncrementalSlots();
     }
 
     public async Task<bool> IsNameInUseAsync(string name)

--- a/src/Data/Game.Persistence/Extensions/QueryExtensions.cs
+++ b/src/Data/Game.Persistence/Extensions/QueryExtensions.cs
@@ -41,6 +41,16 @@ public static class QueryExtensions
             GuildId = x.GuildId
         });
     }
+    
+    public static PlayerData[] AssignIncrementalSlots(this PlayerData[] players)
+    {
+        for (var i = 0; i < players.Length; i++)
+        {
+            players[i].Slot = (byte)i;
+        }
+
+        return players;
+    }
 
     public static IQueryable<Skill> SelectPlayerSkill(this IQueryable<PlayerSkill> query)
     {

--- a/src/Libraries/Game.Server/Commands/PhaseSelectCommand.cs
+++ b/src/Libraries/Game.Server/Commands/PhaseSelectCommand.cs
@@ -36,7 +36,6 @@ namespace QuantumCore.Game.Commands
             context.Player.Connection.SetPhase(EPhases.Select);
 
             var characters = new Characters();
-            var i = 0;
             await using var scope = _serviceProvider.CreateAsyncScope();
             var playerManager = scope.ServiceProvider.GetRequiredService<IPlayerManager>();
             var guildManager = scope.ServiceProvider.GetRequiredService<IGuildManager>();
@@ -46,14 +45,12 @@ namespace QuantumCore.Game.Commands
                 var host = _world.GetMapHost(player.PositionX, player.PositionY);
                 var guild = await guildManager.GetGuildForPlayerAsync(player.Id);
 
-                // todo character slot position
-                characters.CharacterList[i] = player.ToCharacter();
-                characters.CharacterList[i].Ip = BitConverter.ToInt32(host.Ip.GetAddressBytes());
-                characters.CharacterList[i].Port = host.Port;
-                characters.GuildIds[i] = guild?.Id ?? 0;
-                characters.GuildNames[i] = guild?.Name ?? "";
-
-                i++;
+                var slot = (int)player.Slot;
+                characters.CharacterList[slot] = player.ToCharacter();
+                characters.CharacterList[slot].Ip = BitConverter.ToInt32(host.Ip.GetAddressBytes());
+                characters.CharacterList[slot].Port = host.Port;
+                characters.GuildIds[slot] = guild?.Id ?? 0;
+                characters.GuildNames[slot] = guild?.Name ?? "";
             }
 
             context.Player.Connection.Send(characters);

--- a/src/Libraries/Game.Server/Extensions/PaketExtensions.cs
+++ b/src/Libraries/Game.Server/Extensions/PaketExtensions.cs
@@ -9,7 +9,7 @@ public static class PaketExtensions
     {
         return new Character
         {
-            Id = 1,
+            Id = player.Id,
             Name = player.Name,
             Class = player.PlayerClass,
             Level = player.Level,

--- a/src/Libraries/Game.Server/PacketHandlers/TokenLoginHandler.cs
+++ b/src/Libraries/Game.Server/PacketHandlers/TokenLoginHandler.cs
@@ -81,22 +81,18 @@ namespace QuantumCore.Game.PacketHandlers
 
             // Load players of account
             var characters = new Characters();
-            var i = 0;
             var charactersFromCacheOrDb = await _playerManager.GetPlayers(token.AccountId);
             foreach (var player in charactersFromCacheOrDb)
             {
                 var host = _world.GetMapHost(player.PositionX, player.PositionY);
 
                 var guild = await _guildManager.GetGuildForPlayerAsync(player.Id, cancellationToken);
-                // todo character slot position
-                characters.CharacterList[i] = player.ToCharacter();
-                characters.CharacterList[i].Ip = BitConverter.ToInt32(host.Ip.GetAddressBytes());
-                characters.CharacterList[i].Port = host.Port;
-                characters.GuildIds[i] = guild?.Id ?? 0;
-                characters.GuildNames[i] = guild?.Name ?? "";
-                // todo armor on character select
-
-                i++;
+                var slot = (int)player.Slot;
+                characters.CharacterList[slot] = player.ToCharacter();
+                characters.CharacterList[slot].Ip = BitConverter.ToInt32(host.Ip.GetAddressBytes());
+                characters.CharacterList[slot].Port = host.Port;
+                characters.GuildIds[slot] = guild?.Id ?? 0;
+                characters.GuildNames[slot] = guild?.Name ?? "";
             }
 
             // When there are no characters belonging to the account, the empire status is stored in the cache.


### PR DESCRIPTION
Because from the DB query `GetPlayersAsync(Guid accountId)` the `Slot` field was not being populated (always zero), the `players:` cache keys were overwritten when more than one character was created for an account:

```csharp
    public async Task<PlayerData?> GetPlayerAsync(Guid accountId, byte slot)
    {
        var key = $"players:{accountId.ToString()}:{slot}";
        return await _cacheManager.Get<PlayerData>(key);
    }

    public async Task SetPlayerAsync(PlayerData player)
    {
        await _cacheManager.Set($"player:{player.Id.ToString()}", player);
        await _cacheManager.Set($"players:{player.AccountId.ToString()}:{player.Slot}", player);
    }
 ```