### PR TITLE
fix(game): send bound IP addr on Characters packet with 0.0.0.0 config

### DIFF
--- a/src/Core/Core/Networking/Connection.cs
+++ b/src/Core/Core/Networking/Connection.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Collections.Concurrent;
+using System.Net;
 using System.Net.Sockets;
 using System.Text.Json;
 using Microsoft.Extensions.Hosting;
@@ -27,6 +28,8 @@ namespace QuantumCore.Core.Networking
         private long _lastHandshakeTime;
         private CancellationTokenSource? _cts;
 
+        public IPAddress BoundIpAddress { get; private set; }
+
         public Guid Id { get; }
         public uint Handshake { get; private set; }
         public bool Handshaking { get; private set; }
@@ -43,6 +46,7 @@ namespace QuantumCore.Core.Networking
         public void Init(TcpClient client)
         {
             _client = client;
+            BoundIpAddress = ((IPEndPoint)_client.Client.LocalEndPoint!).Address;
             _cts = new CancellationTokenSource();
             Task.Factory.StartNew(SendPacketsWhenAvailable, TaskCreationOptions.LongRunning);
         }

--- a/src/CorePluginAPI/IGameConnection.cs
+++ b/src/CorePluginAPI/IGameConnection.cs
@@ -1,4 +1,5 @@
-﻿using QuantumCore.API.Core.Models;
+﻿using System.Net;
+using QuantumCore.API.Core.Models;
 using QuantumCore.API.Game.World;
 
 namespace QuantumCore.API;
@@ -6,6 +7,7 @@ namespace QuantumCore.API;
 public interface IGameConnection : IConnection
 {
     IServerBase Server { get; }
+    IPAddress BoundIpAddress { get; }
     Guid? AccountId { get; set; }
     string Username { get; set; }
     IPlayerEntity? Player { get; set; }

--- a/src/Game.Benchmarks/Benchmarks/WorldUpdateBenchmark.cs
+++ b/src/Game.Benchmarks/Benchmarks/WorldUpdateBenchmark.cs
@@ -1,4 +1,5 @@
-﻿using BenchmarkDotNet.Attributes;
+﻿using System.Net;
+using BenchmarkDotNet.Attributes;
 using Core.Persistence.Extensions;
 using Game.Caching.Extensions;
 using Microsoft.Extensions.Configuration;
@@ -118,6 +119,7 @@ public class WorldUpdateBenchmark
                 Name = i.ToString(), PlayerClass = EPlayerClassGendered.NinjaFemale, PositionX = 1, PositionY = 1
             };
             var conn = Substitute.For<IGameConnection>();
+            conn.BoundIpAddress.Returns(IPAddress.Loopback);
             var entity = ActivatorUtilities.CreateInstance<PlayerEntity>(services, _world, player, conn);
             _world.SpawnEntity(entity);
         }

--- a/src/Libraries/Game.Server/GameConnection.cs
+++ b/src/Libraries/Game.Server/GameConnection.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Sockets;
+﻿using System.Net;
+using System.Net.Sockets;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using QuantumCore.API;

--- a/src/Tests/Game.Commands.Tests/NonStrictCommandManagerTests.cs
+++ b/src/Tests/Game.Commands.Tests/NonStrictCommandManagerTests.cs
@@ -1,4 +1,5 @@
-﻿using AwesomeAssertions;
+﻿using System.Net;
+using AwesomeAssertions;
 using Game.Commands.Tests.Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -27,6 +28,7 @@ public class NonStrictCommandManagerTests
                 player.When(x => x.SendChatInfo(Arg.Any<string>())).Do(info => _chatInfos.Add(info.Arg<string>()));
                 var conn = Substitute.For<IGameConnection>();
                 conn.Player.Returns(player);
+                conn.BoundIpAddress.Returns(IPAddress.Loopback);
                 return conn;
             })
             .AddSingleton<IConfiguration>(_ => new ConfigurationBuilder().Build())

--- a/src/Tests/Game.Commands.Tests/StrictCommandManagerTests.cs
+++ b/src/Tests/Game.Commands.Tests/StrictCommandManagerTests.cs
@@ -1,4 +1,5 @@
-﻿using AwesomeAssertions;
+﻿using System.Net;
+using AwesomeAssertions;
 using CommandLine;
 using Game.Commands.Tests.Extensions;
 using Microsoft.Extensions.Configuration;
@@ -28,6 +29,7 @@ public class StrictCommandManagerTests
                 player.When(x => x.SendChatInfo(Arg.Any<string>())).Do(info => _chatInfos.Add(info.Arg<string>()));
                 var conn = Substitute.For<IGameConnection>();
                 conn.Player.Returns(player);
+                conn.BoundIpAddress.Returns(IPAddress.Loopback);
                 return conn;
             })
             .AddSingleton<IConfiguration>(_ => new ConfigurationBuilder()

--- a/src/Tests/Game.Tests/CommandTests.cs
+++ b/src/Tests/Game.Tests/CommandTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Text;
 using AutoBogus;
 using AwesomeAssertions;
@@ -75,6 +76,7 @@ internal class MockedGameConnection : IGameConnection
     }
 
     public IServerBase Server { get; } = Substitute.For<IServerBase>();
+    public IPAddress BoundIpAddress { get; } = IPAddress.Loopback;
     public Guid? AccountId { get; set; } = Guid.NewGuid();
     public string Username { get; set; } = "";
     public IPlayerEntity? Player { get; set; }

--- a/src/Tests/Game.Tests/TokenLoginHandlerTests.cs
+++ b/src/Tests/Game.Tests/TokenLoginHandlerTests.cs
@@ -1,0 +1,142 @@
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using QuantumCore.API;
+using QuantumCore.API.Core.Models;
+using QuantumCore.API.Game.Guild;
+using QuantumCore.API.Game.Types;
+using QuantumCore.API.Game.World;
+using QuantumCore.Auth.Cache;
+using QuantumCore.Caching;
+using QuantumCore.Game;
+using QuantumCore.Game.PacketHandlers;
+using QuantumCore.Game.Packets;
+using QuantumCore.Networking;
+using Xunit;
+
+namespace Game.Tests;
+
+public class TokenLoginHandlerTests
+{
+    [Theory]
+    [InlineData("0.0.0.0", "127.0.0.1", "127.0.0.1")]
+    [InlineData("0.0.0.0", "172.16.165.1", "172.16.165.1")]
+    [InlineData("127.0.0.1", "127.0.0.1", "127.0.0.1")]
+    [InlineData("198.51.100.10", "198.51.100.10", "198.51.100.10")]
+    [InlineData("93.184.216.34", "93.184.216.34", "93.184.216.34")]
+    public async Task ExecuteAsync_AdvertisesExpectedCharacterHost(
+        string mapHostIp,
+        string connectionInterfaceIp,
+        string expectedAdvertisedIp)
+    {
+        var parsedMapHostIp = IPAddress.Parse(mapHostIp);
+        var parsedConnectionInterfaceIp = IPAddress.Parse(connectionInterfaceIp);
+        var parsedExpectedAdvertisedIp = IPAddress.Parse(expectedAdvertisedIp);
+
+        var harness = new TokenLoginHandlerTestHarness(
+            parsedMapHostIp,
+            parsedConnectionInterfaceIp);
+
+        var characters = await harness.ExecuteAsync();
+
+        var expectedIpInt = BitConverter.ToInt32(parsedExpectedAdvertisedIp.GetAddressBytes());
+        var actualIpInt = characters.CharacterList[0].Ip;
+
+        Assert.Equal(expectedIpInt, actualIpInt);
+    }
+
+    private sealed class TokenLoginHandlerTestHarness
+    {
+        private readonly IGameConnection _connection;
+        private readonly TokenLoginHandler _handler;
+        private readonly TokenLogin _tokenLogin;
+        private Characters? _characters;
+
+        public TokenLoginHandlerTestHarness(IPAddress mapHostIp, IPAddress connectionInterfaceIp)
+        {
+            var cacheManager = Substitute.For<ICacheManager>();
+            var world = Substitute.For<IWorld>();
+            var playerManager = Substitute.For<IPlayerManager>();
+            var guildManager = Substitute.For<IGuildManager>();
+            var serverStore = Substitute.For<IRedisStore>();
+            var sharedStore = Substitute.For<IRedisStore>();
+
+            cacheManager.Server.Returns(serverStore);
+            cacheManager.Shared.Returns(sharedStore);
+
+            const string Username = "test-user";
+            var accountId = Guid.Parse("df2ce2b2-e1b9-46e4-9d62-991b8b590d1b");
+            const uint TokenKey = 0xDEADBEEFu;
+            var tokenCacheKey = $"token:{TokenKey}";
+            var accountTokenKey = $"account:token:{accountId}";
+
+            serverStore.Exists(tokenCacheKey).Returns(new ValueTask<long>(1));
+            serverStore.Get<Token>(tokenCacheKey).Returns(new ValueTask<Token>(new Token
+            {
+                AccountId = accountId,
+                Username = Username
+            }));
+            sharedStore.Get<uint>(accountTokenKey).Returns(new ValueTask<uint>(0));
+            serverStore.Persist(tokenCacheKey).Returns(new ValueTask<long>(1));
+            sharedStore.Expire(accountTokenKey, Arg.Any<TimeSpan>()).Returns(new ValueTask<long>(1));
+            serverStore.Set(Arg.Any<string>(), Arg.Any<object>()).Returns(new ValueTask<string>("OK"));
+
+            var player = new PlayerData
+            {
+                Id = 100,
+                AccountId = accountId,
+                Name = "TestPlayer",
+                PlayerClass = EPlayerClassGendered.NinjaFemale,
+                Slot = 0,
+                PositionX = 100,
+                PositionY = 200,
+                Empire = EEmpire.Shinsoo
+            };
+
+            playerManager.GetPlayers(accountId).Returns(Task.FromResult(new[] {player}));
+            guildManager.GetGuildForPlayerAsync(player.Id, Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult<GuildData?>(null));
+
+            var coreHost = new CoreHost {Ip = mapHostIp, Port = 13000};
+            world.GetMapHost(Arg.Any<int>(), Arg.Any<int>()).Returns(coreHost);
+
+            var serverBase = Substitute.For<IServerBase>();
+            serverBase.IpAddress.Returns(connectionInterfaceIp);
+            serverBase.Port.Returns(coreHost.Port);
+
+            var phase = EPhases.Handshake;
+            var assignedAccountId = (Guid?) null;
+            var assignedUsername = string.Empty;
+
+            var connection = Substitute.For<IGameConnection>();
+            connection.Server.Returns(serverBase);
+            connection.BoundIpAddress.Returns(connectionInterfaceIp);
+            connection.Phase.Returns(_ => phase);
+            connection.When(x => x.Phase = Arg.Any<EPhases>()).Do(ci => phase = ci.Arg<EPhases>());
+            connection.AccountId.Returns(_ => assignedAccountId);
+            connection.When(x => x.AccountId = Arg.Any<Guid?>()).Do(ci => assignedAccountId = ci.Arg<Guid?>());
+            connection.Username.Returns(_ => assignedUsername);
+            connection.When(x => x.Username = Arg.Any<string>()).Do(ci => assignedUsername = ci.Arg<string>());
+            connection.Send(Arg.Do<Characters>(packet => _characters = packet));
+
+            _connection = connection;
+            _tokenLogin = new TokenLogin {Username = Username, Key = TokenKey};
+            _handler = new TokenLoginHandler(Substitute.For<ILogger<TokenLoginHandler>>(), cacheManager, world, playerManager, guildManager);
+        }
+
+        public async Task<Characters> ExecuteAsync()
+        {
+            var context = new GamePacketContext<TokenLogin>
+            {
+                Packet = _tokenLogin,
+                Connection = _connection
+            };
+
+            await _handler.ExecuteAsync(context);
+
+            return _characters ?? throw new InvalidOperationException("Characters packet was not sent.");
+        }
+    }
+}

--- a/src/Tests/Game.Tests/WorldTests.cs
+++ b/src/Tests/Game.Tests/WorldTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -109,6 +110,7 @@ public class WorldTests
         _world.InitAsync().Wait();
 
         var conn = Substitute.For<IGameConnection>();
+        conn.BoundIpAddress.Returns(IPAddress.Loopback);
         var playerData = new PlayerData
         {
             Name = "TestPlayer", PlayerClass = EPlayerClassGendered.NinjaFemale, PositionX = 1, PositionY = 1


### PR DESCRIPTION
Trying to select a character with server appsettings.json `  "Hosting": { "IpAddress": "0.0.0.0" } `, we can see in the `Characters` game packet that `Ip` fields are zero before the fix (which is unroutable for the client, leading to connection drop and back to initial CH select screen). 

With the fix we basically reuse the IP address from the initial TCP handshake (SYN) packet sent from the client, configured in serverinfo.py. (`_client.Client.LocalEndPoint`)

Decided to only override in the case of the server configured with Any addresses (`0.0.0.0` or `::`), since I guess this will be reworked anyway when we support scaling out to multiple cores.