### PR TITLE
SonarScanner configuration with verbose logging

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -51,6 +51,6 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         shell: powershell
         run: |
-          .\.sonar\scanner\dotnet-sonarscanner begin /k:"MeikelLP_quantum-core-x" /o:"meikel" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
-          dotnet build --configuration Release src/QuantumCore.sln
+          .\.sonar\scanner\dotnet-sonarscanner begin /k:"MeikelLP_quantum-core-x" /o:"meikel" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.verbose=true /d:sonar.log.level=DEBUG
+          dotnet build --configuration Release src/QuantumCore.sln -v:n
           .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"


### PR DESCRIPTION
Last PR #397 scan only detected a small subset of changed files. 
https://sonarcloud.io/component_measures?metric=new_lines&selected=MeikelLP_quantum-core-x%3Asrc&view=list&pullRequest=397&id=MeikelLP_quantum-core-x

Github Actions logs show this: (from https://github.com/MeikelLP/quantum-core-x/actions/runs/20309365083/job/58335790800)
```
16:15:17.734  INFO: Found 27 MSBuild C# projects: 8 TEST projects. 19 with no MAIN nor TEST files.
16:15:19.645  INFO: SCM Publisher 4 source files to be analyzed
16:15:20  INFO: SCM Publisher 4/4 source files have been analyzed (done) | time=355ms
```

Fix is not clear, so I suggest enabling verbose logging to debug.