### PR TITLE
game: add entity event registry and logout countdowns

### DIFF
--- a/src/Core/Core/Event/ThreadPoolScheduler.cs
+++ b/src/Core/Core/Event/ThreadPoolScheduler.cs
@@ -1,0 +1,11 @@
+using QuantumCore.API.Core.Event;
+
+namespace QuantumCore.Core.Event;
+
+public sealed class ThreadPoolScheduler : IJobScheduler
+{
+    public void Schedule(Func<Task> work)
+    {
+        Task.Run(work);
+    }
+}

--- a/src/Core/Extensions/ServiceExtensions.cs
+++ b/src/Core/Extensions/ServiceExtensions.cs
@@ -2,8 +2,10 @@ using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using QuantumCore.API.Core.Event;
 using QuantumCore.API.Core.Timekeeping;
 using QuantumCore.API.PluginTypes;
+using QuantumCore.Core.Event;
 using QuantumCore.Networking;
 using Serilog;
 using Serilog.Events;
@@ -85,6 +87,7 @@ public static class ServiceExtensions
         });
         services.AddSingleton(_ => TimeProvider.System);
         services.AddSingleton<ServerClock>();
+        services.AddSingleton<IJobScheduler, ThreadPoolScheduler>();
         services.AddSingleton<PluginExecutor>();
         services.AddPluginFramework()
             .AddPluginCatalog(pluginCatalog)

--- a/src/CorePluginAPI/Core/Event/IJobScheduler.cs
+++ b/src/CorePluginAPI/Core/Event/IJobScheduler.cs
@@ -1,0 +1,6 @@
+namespace QuantumCore.API.Core.Event;
+
+public interface IJobScheduler
+{
+    void Schedule(Func<Task> work);
+}

--- a/src/CorePluginAPI/Core/Timekeeping/PlayerTimestampKind.cs
+++ b/src/CorePluginAPI/Core/Timekeeping/PlayerTimestampKind.cs
@@ -1,0 +1,14 @@
+namespace QuantumCore.API.Core.Timekeeping;
+
+public enum PlayerTimestampKind
+{
+    DIED,
+    RESPAWNED,
+    DAMAGE_TAKEN,
+    DAMAGE_DEALT,
+    USED_SKILL,
+    ATTACK_INITIATED,
+    RESTORED_HEALTH,
+    RESTORED_MANA,
+    AUTOSAVED
+}

--- a/src/CorePluginAPI/Core/Timekeeping/TimestampRegistry.cs
+++ b/src/CorePluginAPI/Core/Timekeeping/TimestampRegistry.cs
@@ -1,0 +1,97 @@
+using EnumsNET;
+
+namespace QuantumCore.API.Core.Timekeeping;
+
+/// <summary>
+/// Simple enum-indexed storage for optional server timestamps.
+/// Made thread-safe using <see cref="System.Threading.Lock"/>.
+/// </summary>
+public sealed class TimestampRegistry<TKind> where TKind : struct, Enum
+{
+    private static readonly int MaxEnumValue = Enums.GetValues<TKind>().Select(Enums.ToInt32).Max();
+
+    private readonly Lock _lock = new();
+    private readonly ServerTimestamp?[] _slots = new ServerTimestamp?[MaxEnumValue + 1];
+
+    public ServerTimestamp? this[TKind kind]
+    {
+        get => Get(kind);
+        set
+        {
+            if (value.HasValue)
+            {
+                Mark(kind, value.Value);
+            }
+            else
+            {
+                Clear(kind);
+            }
+        }
+    }
+    
+    public void Mark(TKind kind, ServerTimestamp timestamp)
+    {
+        lock (_lock)
+        {
+            _slots[Enums.ToInt32(kind)] = timestamp;
+        }
+    }
+
+    public void Clear(TKind kind)
+    {
+        lock (_lock)
+        {
+            _slots[Enums.ToInt32(kind)] = null;
+        }
+    }
+
+    public bool UpdateIfElapsed(TickContext ctx, TKind kind, TimeSpan minimumElapsed)
+    {
+        // need lock for transactional update (check-then-act)
+        lock (_lock)
+        {
+            var ts = _slots[Enums.ToInt32(kind)];
+            if (ts.HasValue)
+            {
+                var tickTimestampOutsideGracePeriod = ctx.ElapsedSince(ts) > minimumElapsed;
+                if (tickTimestampOutsideGracePeriod)
+                {
+                    _slots[Enums.ToInt32(kind)] = ctx.Timestamp;
+                    return true;
+                }
+            }
+            else
+            {
+                _slots[Enums.ToInt32(kind)] = ctx.Timestamp;
+            }
+
+            return false;
+        }
+    }
+
+    public ServerTimestamp? Get(TKind kind)
+    {
+        lock (_lock)
+        {
+            return _slots[Enums.ToInt32(kind)];
+        }
+    }
+    
+    public ServerTimestamp? LatestOf(params TKind[] kinds)
+    {
+        lock (_lock)
+        {
+            ServerTimestamp? latest = null;
+            foreach (var kind in kinds)
+            {
+                var ts = _slots[Enums.ToInt32(kind)];
+                if (ts > latest)
+                {
+                    latest = ts;
+                }
+            }
+
+            return latest;
+        }
+    }
+}

--- a/src/CorePluginAPI/CorePluginAPI.csproj
+++ b/src/CorePluginAPI/CorePluginAPI.csproj
@@ -1,16 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <RootNamespace>QuantumCore.API</RootNamespace>
-    </PropertyGroup>
+  <PropertyGroup>
+    <RootNamespace>QuantumCore.API</RootNamespace>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="BinarySerializer" Version="8.6.4.1"/>
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.11"/>
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="BinarySerializer" Version="8.6.4.1"/>
+    <PackageReference Include="Enums.NET" Version="5.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.11"/>
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Core.Networking\Core.Networking.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Core.Networking\Core.Networking.csproj"/>
+  </ItemGroup>
 
 </Project>

--- a/src/CorePluginAPI/Game/World/IEntity.cs
+++ b/src/CorePluginAPI/Game/World/IEntity.cs
@@ -63,4 +63,5 @@ public interface IEntity
     public void Move(int x, int y);
     public void Stop();
     public void Die();
+    public bool TryScheduleKnockout();
 }

--- a/src/CorePluginAPI/Game/World/IEntity.cs
+++ b/src/CorePluginAPI/Game/World/IEntity.cs
@@ -63,5 +63,5 @@ public interface IEntity
     public void Move(int x, int y);
     public void Stop();
     public void Die();
-    public bool TryScheduleKnockout();
+    public bool TryKnockout();
 }

--- a/src/CorePluginAPI/Game/World/IPlayerEntity.cs
+++ b/src/CorePluginAPI/Game/World/IPlayerEntity.cs
@@ -1,4 +1,5 @@
 using QuantumCore.API.Core.Models;
+using QuantumCore.API.Core.Timekeeping;
 using QuantumCore.API.Game.Skills;
 using QuantumCore.API.Game.Types.Entities;
 using QuantumCore.API.Game.Types.Items;
@@ -24,6 +25,7 @@ public interface IPlayerEntity : IEntity
     Dictionary<string, IQuest> Quests { get; }
     EAntiFlags AntiFlagClass { get; }
     EAntiFlags AntiFlagGender { get; }
+    TimestampRegistry<PlayerTimestampKind> Timeline { get; }
 
     Task Load();
     Task ReloadPermissions();

--- a/src/CorePluginAPI/IGroundItem.cs
+++ b/src/CorePluginAPI/IGroundItem.cs
@@ -8,4 +8,5 @@ public interface IGroundItem : IEntity
     ItemInstance Item { get; }
     uint Amount { get; }
     string? OwnerName { get; }
+    bool ReleaseOwnership();
 }

--- a/src/CorePluginAPI/Systems/Events/IEventSlot.cs
+++ b/src/CorePluginAPI/Systems/Events/IEventSlot.cs
@@ -1,0 +1,7 @@
+namespace QuantumCore.API.Systems.Events;
+
+// Strongly typed wrapper over the raw event ID; null id signifies unscheduled
+public interface IEventSlot
+{
+    long? EventId { get; set; }
+}

--- a/src/CorePluginAPI/Systems/Events/ISchedulable.cs
+++ b/src/CorePluginAPI/Systems/Events/ISchedulable.cs
@@ -1,0 +1,15 @@
+using QuantumCore.API.Game.World;
+
+namespace QuantumCore.API.Systems.Events;
+
+public interface ISchedulable<in TEntity> : IEventSlot where TEntity : IEntity
+{
+    long EnqueueEvent(TEntity entity);
+    bool Cancel();
+}
+
+public interface ISchedulable<in TEntity, in TArgs> : IEventSlot where TEntity : IEntity
+{
+    long EnqueueEvent(TEntity entity, TArgs args);
+    bool Cancel();
+}

--- a/src/Libraries/Game.Server/Commands/PhaseSelectCommand.cs
+++ b/src/Libraries/Game.Server/Commands/PhaseSelectCommand.cs
@@ -6,6 +6,8 @@ using QuantumCore.API.Game.World;
 using QuantumCore.Extensions;
 using QuantumCore.Game.Extensions;
 using QuantumCore.Game.Packets;
+using QuantumCore.Game.Systems.Events;
+using QuantumCore.Game.World.Entities;
 
 namespace QuantumCore.Game.Commands;
 
@@ -14,45 +16,61 @@ namespace QuantumCore.Game.Commands;
 public class PhaseSelectCommand : ICommandHandler
 {
     private readonly IWorld _world;
-    private readonly IServiceProvider _serviceProvider;
+    private readonly IServiceScopeFactory _scopeFactory;
 
-    public PhaseSelectCommand(IWorld world, IServiceProvider serviceProvider)
+    public PhaseSelectCommand(IWorld world, IServiceScopeFactory scopeFactory)
     {
         _world = world;
-        _serviceProvider = serviceProvider;
+        _scopeFactory = scopeFactory;
     }
 
-    public async Task ExecuteAsync(CommandContext context)
+    public Task ExecuteAsync(CommandContext context)
     {
-        if (context.Player.Connection.AccountId is null) return;
-
-        context.Player.SendChatInfo("Going back to character selection. Please wait.");
-
-        // todo implement wait
-
-        await context.Player.CalculatePlayedTimeAsync();
-
-        await _world.DespawnPlayerAsync(context.Player);
-        context.Player.Connection.SetPhase(EPhase.SELECT);
-
-        var characters = new Characters();
-        await using var scope = _serviceProvider.CreateAsyncScope();
-        var playerManager = scope.ServiceProvider.GetRequiredService<IPlayerManager>();
-        var guildManager = scope.ServiceProvider.GetRequiredService<IGuildManager>();
-        var charactersFromCacheOrDb = await playerManager.GetPlayers(context.Player.Connection.AccountId.Value);
-        foreach (var player in charactersFromCacheOrDb)
+        if (context.Player is not PlayerEntity { Events: var events } player)
         {
-            var host = _world.GetMapHost(player.PositionX, player.PositionY);
-            var guild = await guildManager.GetGuildForPlayerAsync(player.Id);
-
-            var slot = (int)player.Slot;
-            characters.CharacterList[slot] = player.ToCharacter();
-            characters.CharacterList[slot].Ip = BitConverter.ToInt32(host._ip.GetAddressBytes());
-            characters.CharacterList[slot].Port = host._port;
-            characters.GuildIds[slot] = guild?.Id ?? 0;
-            characters.GuildNames[slot] = guild?.Name ?? "";
+            throw new NotImplementedException();
         }
 
-        context.Player.Connection.Send(characters);
+        // toggle mechanism
+        if (events.Cancel(events.SafeLogoutCountdown))
+        {
+            player.SendChatInfo("Your logout has been cancelled.");
+            return Task.CompletedTask;
+        }
+
+        if (player.Connection.AccountId is null) return Task.CompletedTask;
+
+        player.SendChatInfo("Going back to character selection. Please wait.");
+
+        events.Schedule(events.SafeLogoutCountdown, new SafeLogoutCountdownEvent.Args(
+            "{0} seconds until character selection.",
+            async () =>
+            {
+                await player.CalculatePlayedTimeAsync();
+                await _world.DespawnPlayerAsync(player);
+                player.Connection.SetPhase(EPhase.SELECT);
+
+                var characters = new Characters();
+                await using var scope = _scopeFactory.CreateAsyncScope();
+                var playerManager = scope.ServiceProvider.GetRequiredService<IPlayerManager>();
+                var guildManager = scope.ServiceProvider.GetRequiredService<IGuildManager>();
+                var charactersFromCacheOrDb = await playerManager.GetPlayers(player.Connection.AccountId.Value);
+                foreach (var playerData in charactersFromCacheOrDb)
+                {
+                    var host = _world.GetMapHost(playerData.PositionX, playerData.PositionY);
+                    var guild = await guildManager.GetGuildForPlayerAsync(playerData.Id);
+
+                    var slot = (int)playerData.Slot;
+                    characters.CharacterList[slot] = playerData.ToCharacter();
+                    characters.CharacterList[slot].Ip = BitConverter.ToInt32(host._ip.GetAddressBytes());
+                    characters.CharacterList[slot].Port = host._port;
+                    characters.GuildIds[slot] = guild?.Id ?? 0;
+                    characters.GuildNames[slot] = guild?.Name ?? "";
+                }
+
+                player.Connection.Send(characters);
+            }));
+
+        return Task.CompletedTask;
     }
 }

--- a/src/Libraries/Game.Server/Commands/PurgeCommand.cs
+++ b/src/Libraries/Game.Server/Commands/PurgeCommand.cs
@@ -13,7 +13,9 @@ public class PurgeCommand : ICommandHandler<PurgeCommandOptions>
         const int MAX_DISTANCE = 10000;
         var p = context.Player;
         var all = context.Arguments.Argument == PurgeCommandOption.ALL;
-        foreach (var e in context.Player.Map!.Entities)
+        // hack to avoid System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
+        var mapEntitiesSnapshot = context.Player.Map!.Entities.AsEnumerable().ToArray();
+        foreach (var e in mapEntitiesSnapshot)
         {
             if (e is IPlayerEntity) continue;
             var distance = MathUtils.Distance(e.PositionX, e.PositionY, p.PositionX, p.PositionY);

--- a/src/Libraries/Game.Server/Commands/RestartHereCommand.cs
+++ b/src/Libraries/Game.Server/Commands/RestartHereCommand.cs
@@ -1,4 +1,7 @@
-﻿using QuantumCore.API.Game;
+﻿using QuantumCore.API.Core.Timekeeping;
+using QuantumCore.API.Game;
+using QuantumCore.API.Game.World;
+using QuantumCore.Game.Constants;
 
 namespace QuantumCore.Game.Commands;
 
@@ -8,7 +11,41 @@ public class RestartHereCommand : ICommandHandler
 {
     public Task ExecuteAsync(CommandContext context)
     {
-        context.Player.Respawn(false);
+        context.Player.RestartWithCooldown(false);
         return Task.CompletedTask;
+    }
+}
+
+internal static class PlayerRestartCommandExtensions
+{
+    internal static void RestartWithCooldown(this IPlayerEntity player, bool inTown)
+    {
+        if (!player.Dead)
+        {
+            // cannot restart if alive
+            return;
+        }
+
+        if (player.Timeline[PlayerTimestampKind.DIED] is not { } deathTimestamp)
+        {
+            // timestamp should be set if dead
+            return;
+        }
+
+        var clock = player.Connection.Server.Clock;
+        var validRestartTimestamp = clock.Advance(deathTimestamp, inTown
+            ? SchedulingConstants.RestartTownMinWait
+            : SchedulingConstants.RestartHereMinWait);
+
+        if (clock.Now < validRestartTimestamp)
+        {
+            var remaining = clock.ElapsedBetween(clock.Now, validRestartTimestamp);
+            var remainingSeconds = (int)Math.Ceiling(remaining.TotalSeconds);
+            player.SendChatInfo($"Cannot restart, please wait {remainingSeconds} seconds.");
+
+            return;
+        }
+
+        player.Respawn(inTown);
     }
 }

--- a/src/Libraries/Game.Server/Commands/RestartTownCommand.cs
+++ b/src/Libraries/Game.Server/Commands/RestartTownCommand.cs
@@ -8,7 +8,7 @@ public class RestartTownCommand : ICommandHandler
 {
     public Task ExecuteAsync(CommandContext context)
     {
-        context.Player.Respawn(true);
+        context.Player.RestartWithCooldown(true);
         return Task.CompletedTask;
     }
 }

--- a/src/Libraries/Game.Server/Constants/SchedulingConstants.cs
+++ b/src/Libraries/Game.Server/Constants/SchedulingConstants.cs
@@ -1,0 +1,22 @@
+namespace QuantumCore.Game.Constants;
+
+public static class SchedulingConstants
+{
+    public const int LOGOUT_WAIT_SECONDS = 3;
+    public const int LOGOUT_COMBAT_WAIT_SECONDS = 10;
+    public const int LOGOUT_COMBAT_GRACE_PERIOD_SECONDS = 10;
+
+    public static readonly TimeSpan GroundItemOwnershipLock = TimeSpan.FromSeconds(30);
+    public static readonly TimeSpan GroundItemLifetime = TimeSpan.FromSeconds(300);
+
+    public static readonly TimeSpan PlayerAutoRespawnDelay = TimeSpan.FromSeconds(180);
+    public static readonly TimeSpan RestartHereMinWait = TimeSpan.FromSeconds(10);
+    public static readonly TimeSpan RestartTownMinWait = TimeSpan.FromSeconds(7);
+
+    public static readonly TimeSpan KnockoutToDeathDelay = TimeSpan.FromSeconds(3);
+    public static readonly TimeSpan MonsterDespawnAfterDeath = TimeSpan.FromSeconds(5);
+
+    public static readonly TimeSpan PlayerAutosaveInterval = TimeSpan.FromSeconds(30);
+    public static readonly TimeSpan PlayerManaRegenInterval = TimeSpan.FromSeconds(3);
+    public static readonly TimeSpan PlayerHealthRegenInterval = TimeSpan.FromSeconds(3);
+}

--- a/src/Libraries/Game.Server/Extensions/PaketExtensions.cs
+++ b/src/Libraries/Game.Server/Extensions/PaketExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using QuantumCore.API.Core.Models;
 using QuantumCore.API.Game.Types.Players;
+using QuantumCore.API.Game.World;
 using QuantumCore.Game.Packets;
+using QuantumCore.Networking;
 
 namespace QuantumCore.Game.Extensions;
 
@@ -26,5 +28,23 @@ public static class PaketExtensions
             PositionY = player.PositionY,
             SkillGroup = player.SkillGroup
         };
+    }
+    
+    public static void SafeBroadcastNearby<T>(this IEntity entity, T packet, bool includeSelf = true) where T : IPacketSerializable
+    {
+        if (includeSelf && entity is IPlayerEntity player)
+        {
+            player.Connection.Send(packet);
+        }
+
+        // take a snapshot to avoid enumeration failure if the nearby list is being mutated while we send
+        var nearbySnapshot = entity.NearbyEntities.AsEnumerable().ToArray();
+
+        foreach (var nearbyPlayer in nearbySnapshot
+                     .Where(x => x is IPlayerEntity)
+                     .Cast<IPlayerEntity>())
+        {
+            nearbyPlayer.Connection.Send(packet);
+        }
     }
 }

--- a/src/Libraries/Game.Server/Extensions/PaketExtensions.cs
+++ b/src/Libraries/Game.Server/Extensions/PaketExtensions.cs
@@ -30,7 +30,7 @@ public static class PaketExtensions
         };
     }
     
-    public static void SafeBroadcastNearby<T>(this IEntity entity, T packet, bool includeSelf = true) where T : IPacketSerializable
+    public static void BroadcastNearby<T>(this IEntity entity, T packet, bool includeSelf = true) where T : IPacketSerializable
     {
         if (includeSelf && entity is IPlayerEntity player)
         {
@@ -40,9 +40,7 @@ public static class PaketExtensions
         // take a snapshot to avoid enumeration failure if the nearby list is being mutated while we send
         var nearbySnapshot = entity.NearbyEntities.AsEnumerable().ToArray();
 
-        foreach (var nearbyPlayer in nearbySnapshot
-                     .Where(x => x is IPlayerEntity)
-                     .Cast<IPlayerEntity>())
+        foreach (var nearbyPlayer in nearbySnapshot.OfType<IPlayerEntity>())
         {
             nearbyPlayer.Connection.Send(packet);
         }

--- a/src/Libraries/Game.Server/PacketHandlers/Game/CharacterMoveHandler.cs
+++ b/src/Libraries/Game.Server/PacketHandlers/Game/CharacterMoveHandler.cs
@@ -84,7 +84,7 @@ public class CharacterMoveHandler : IGamePacketHandler<CharacterMove>
                 : 0
         };
 
-        ctx.Connection.Player.SafeBroadcastNearby(movement, includeSelf: false);
+        ctx.Connection.Player.BroadcastNearby(movement, includeSelf: false);
         
         return Task.CompletedTask;
     }

--- a/src/Libraries/Game.Server/PacketHandlers/Game/CharacterMoveHandler.cs
+++ b/src/Libraries/Game.Server/PacketHandlers/Game/CharacterMoveHandler.cs
@@ -4,8 +4,8 @@ using QuantumCore.API;
 using QuantumCore.API.Game.Types.Players;
 using QuantumCore.API.Game.Types.Skills;
 using QuantumCore.API.PluginTypes;
+using QuantumCore.Game.Extensions;
 using QuantumCore.Game.Packets;
-using QuantumCore.Game.World.Entities;
 
 namespace QuantumCore.Game.PacketHandlers.Game;
 
@@ -84,14 +84,8 @@ public class CharacterMoveHandler : IGamePacketHandler<CharacterMove>
                 : 0
         };
 
-        foreach (var entity in ctx.Connection.Player.NearbyEntities)
-        {
-            if (entity is PlayerEntity player)
-            {
-                player.Connection.Send(movement);
-            }
-        }
-
+        ctx.Connection.Player.SafeBroadcastNearby(movement, includeSelf: false);
+        
         return Task.CompletedTask;
     }
 }

--- a/src/Libraries/Game.Server/PacketHandlers/Game/SyncPositionsHandler.cs
+++ b/src/Libraries/Game.Server/PacketHandlers/Game/SyncPositionsHandler.cs
@@ -36,7 +36,7 @@ public class SyncPositionsHandler : IGamePacketHandler<SyncPositions>
             return Task.CompletedTask;
         }
 
-        player.SafeBroadcastNearby(new SyncPositionsOut { Positions = positions.ToArray() }, false);
+        player.BroadcastNearby(new SyncPositionsOut { Positions = positions.ToArray() }, includeSelf: false);
 
         return Task.CompletedTask;
     }

--- a/src/Libraries/Game.Server/PacketHandlers/Game/SyncPositionsHandler.cs
+++ b/src/Libraries/Game.Server/PacketHandlers/Game/SyncPositionsHandler.cs
@@ -1,0 +1,43 @@
+using QuantumCore.API;
+using QuantumCore.API.PluginTypes;
+using QuantumCore.Game.Extensions;
+using QuantumCore.Game.Packets;
+using QuantumCore.Game.World;
+using static QuantumCore.API.Game.Types.Entities.EEntityType;
+
+namespace QuantumCore.Game.PacketHandlers.Game;
+
+public class SyncPositionsHandler : IGamePacketHandler<SyncPositions>
+{
+    public Task ExecuteAsync(GamePacketContext<SyncPositions> ctx, CancellationToken token = default)
+    {
+        if (ctx.Connection.Player is not { Map: Map localMap } player)
+        {
+            return Task.CompletedTask;
+        }
+
+        var positions = new List<SyncPositionElement>(ctx.Packet.Positions.Length);
+        foreach (var position in ctx.Packet.Positions)
+        {
+            var entity = localMap.GetEntity(position.Vid);
+            if (entity is null || entity.Type is NPC or WARP or GOTO)
+            {
+                continue;
+            }
+
+            // TODO: should we sync on the server as well? or only forward to neighboring players?
+            // i.e. entity.Move(position.X, position.Y);
+            
+            positions.Add(position);
+        }
+
+        if (positions.Count == 0)
+        {
+            return Task.CompletedTask;
+        }
+
+        player.SafeBroadcastNearby(new SyncPositionsOut { Positions = positions.ToArray() }, false);
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Libraries/Game.Server/PacketHandlers/Game/UseSkillHandler.cs
+++ b/src/Libraries/Game.Server/PacketHandlers/Game/UseSkillHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using QuantumCore.API;
+using QuantumCore.API.Core.Timekeeping;
 using QuantumCore.API.PluginTypes;
 using QuantumCore.Game.Packets;
 
@@ -16,6 +17,11 @@ public class UseSkillHandler : IGamePacketHandler<PlayerUseSkill>
 
     public Task ExecuteAsync(GamePacketContext<PlayerUseSkill> ctx, CancellationToken token = default)
     {
+        if (ctx.Connection.Player is { Timeline: var timeline })
+        {
+            timeline[PlayerTimestampKind.USED_SKILL] = ctx.Connection.Server.Clock.Now;
+        }
+
         _logger.LogWarning("SkillId: {SkillId} on TargetVid: {TargetVid} not implemented", ctx.Packet.SkillId,
             ctx.Packet.TargetVid);
         return Task.CompletedTask;

--- a/src/Libraries/Game.Server/Packets/KnockoutCharacter.cs
+++ b/src/Libraries/Game.Server/Packets/KnockoutCharacter.cs
@@ -1,0 +1,10 @@
+using QuantumCore.Networking;
+
+namespace QuantumCore.Game.Packets;
+
+[Packet(0x0d, EDirection.OUTGOING)]
+[PacketGenerator]
+public partial class KnockoutCharacter
+{
+    [Field(0)] public uint Vid { get; set; }
+}

--- a/src/Libraries/Game.Server/Packets/SyncPositionElement.cs
+++ b/src/Libraries/Game.Server/Packets/SyncPositionElement.cs
@@ -1,0 +1,10 @@
+using QuantumCore.Networking;
+
+namespace QuantumCore.Game.Packets;
+
+public struct SyncPositionElement
+{
+    [Field(0)] public uint Vid { get; set; }
+    [Field(1)] public int X { get; set; }
+    [Field(2)] public int Y { get; set; }
+}

--- a/src/Libraries/Game.Server/Packets/SyncPositions.cs
+++ b/src/Libraries/Game.Server/Packets/SyncPositions.cs
@@ -1,0 +1,114 @@
+using System.Buffers;
+using QuantumCore.Networking;
+
+namespace QuantumCore.Game.Packets;
+
+[Packet(0x08, EDirection.INCOMING, Sequence = true)]
+// TODO: enhance generator to support variable length arrays by the TotalSize field
+public class SyncPositions : IPacketSerializable
+{
+      private const int ELEMENT_SIZE = 12; // SyncPositionElement = uint + int + int
+      private const int HEADER_SIZE = 1;
+      private const int TOTAL_SIZE_FIELD_SIZE = 2;
+
+      public ushort TotalSize { get; private init; }
+      public SyncPositionElement[] Positions { get; private init; } = [];
+
+      public ushort GetSize()
+      {
+          return (ushort)(TOTAL_SIZE_FIELD_SIZE + Positions.Length * ELEMENT_SIZE);
+      }
+
+      public void Serialize(byte[] bytes, in int offset = 0)
+      {
+          var totalSize = TotalSize != 0
+              ? TotalSize
+              : (ushort)(HEADER_SIZE + TOTAL_SIZE_FIELD_SIZE + Positions.Length * ELEMENT_SIZE);
+          BitConverter.GetBytes(totalSize).CopyTo(bytes, offset);
+
+          for (var i = 0; i < Positions.Length; i++)
+          {
+              var elementOffset = offset + TOTAL_SIZE_FIELD_SIZE + i * ELEMENT_SIZE;
+              var element = Positions[i];
+              BitConverter.GetBytes(element.Vid).CopyTo(bytes, elementOffset);
+              BitConverter.GetBytes(element.X).CopyTo(bytes, elementOffset + 4);
+              BitConverter.GetBytes(element.Y).CopyTo(bytes, elementOffset + 8);
+          }
+      }
+
+      public static SyncPositions Deserialize(ReadOnlySpan<byte> bytes, in int offset = 0)
+      {
+          var totalSize = BitConverter.ToUInt16(bytes.Slice(offset, TOTAL_SIZE_FIELD_SIZE));
+          var payloadSize = Math.Max(0, totalSize - HEADER_SIZE - TOTAL_SIZE_FIELD_SIZE);
+          var count = payloadSize / ELEMENT_SIZE;
+
+          var positions = new SyncPositionElement[count];
+          for (var i = 0; i < count; i++)
+          {
+              var elementOffset = offset + TOTAL_SIZE_FIELD_SIZE + i * ELEMENT_SIZE;
+              positions[i] = new SyncPositionElement
+              {
+                  Vid = BitConverter.ToUInt32(bytes.Slice(elementOffset, 4)),
+                  X = BitConverter.ToInt32(bytes.Slice(elementOffset + 4, 4)),
+                  Y = BitConverter.ToInt32(bytes.Slice(elementOffset + 8, 4))
+              };
+          }
+
+          return new SyncPositions
+          {
+              TotalSize = totalSize,
+              Positions = positions
+          };
+      }
+      
+      public static T Deserialize<T>(ReadOnlySpan<byte> bytes, in int offset = 0)
+          where T : IPacketSerializable
+      {
+          return (T)(object)Deserialize(bytes, offset);
+      }
+
+      public static async ValueTask<object> DeserializeFromStreamAsync(Stream stream)
+      {
+          var buffer = ArrayPool<byte>.Shared.Rent(NetworkingConstants.BufferSize);
+          try
+          {
+              var totalSize = await stream.ReadValueFromStreamAsync<ushort>(buffer);
+              var payloadSize = Math.Max(0, totalSize - HEADER_SIZE - TOTAL_SIZE_FIELD_SIZE);
+              var count = payloadSize / ELEMENT_SIZE;
+
+              var positions = new SyncPositionElement[count];
+              for (var i = 0; i < count; i++)
+              {
+                  positions[i] = new SyncPositionElement
+                  {
+                      Vid = await stream.ReadValueFromStreamAsync<uint>(buffer),
+                      X = await stream.ReadValueFromStreamAsync<int>(buffer),
+                      Y = await stream.ReadValueFromStreamAsync<int>(buffer)
+                  };
+              }
+
+              var remaining = payloadSize - count * ELEMENT_SIZE;
+              while (remaining > 0)
+              {
+                  var chunk = Math.Min(remaining, buffer.Length);
+                  await stream.ReadExactlyAsync(buffer.AsMemory(0, chunk));
+                  remaining -= chunk;
+              }
+
+              return new SyncPositions
+              {
+                  TotalSize = totalSize,
+                  Positions = positions
+              };
+          }
+          finally
+          {
+              ArrayPool<byte>.Shared.Return(buffer);
+          }
+      }
+
+      public static byte Header => 0x08;
+      public static byte? SubHeader => null;
+      public static bool HasStaticSize => false;
+      public static bool HasSequence => true;
+}

--- a/src/Libraries/Game.Server/Packets/SyncPositionsOut.cs
+++ b/src/Libraries/Game.Server/Packets/SyncPositionsOut.cs
@@ -1,0 +1,13 @@
+using QuantumCore.Networking;
+
+namespace QuantumCore.Game.Packets;
+
+[Packet(0x05, EDirection.OUTGOING)]
+[PacketGenerator]
+public partial class SyncPositionsOut
+{
+    // Reference Positions so generator links this as the size field, but use GetSize() for actual value.
+    [Field(0)] public ushort TotalSize => (ushort)(GetSize() + Positions.Length * 0);
+    
+    [Field(1)] public SyncPositionElement[] Positions { get; init; } = [];
+}

--- a/src/Libraries/Game.Server/Systems/Events/EntityEventRegistry.cs
+++ b/src/Libraries/Game.Server/Systems/Events/EntityEventRegistry.cs
@@ -1,0 +1,36 @@
+using QuantumCore.API.Game.World;
+using QuantumCore.API.Systems.Events;
+
+namespace QuantumCore.Game.Systems.Events;
+
+public class EntityEventRegistry<TEntity> : EntityEventRegistryBase where TEntity : IEntity
+{
+    private readonly TEntity _entity;
+
+    protected EntityEventRegistry(TEntity entity) : base(entity)
+    {
+        _entity = entity;
+    }
+
+    public long Schedule(ISchedulable<TEntity> schedulable)
+    {
+        Cancel(schedulable);
+
+        var eventId = schedulable.EnqueueEvent(_entity);
+        schedulable.EventId = eventId;
+        return eventId;
+    }
+
+    public long Schedule<TArgs>(ISchedulable<TEntity, TArgs> schedulable, TArgs args)
+    {
+        Cancel(schedulable);
+
+        var eventId = schedulable.EnqueueEvent(_entity, args);
+        schedulable.EventId = eventId;
+        return eventId;
+    }
+
+    public bool Cancel(ISchedulable<TEntity> schedulable) => schedulable.Cancel();
+
+    public bool Cancel<TArgs>(ISchedulable<TEntity, TArgs> schedulable) => schedulable.Cancel();
+}

--- a/src/Libraries/Game.Server/Systems/Events/EntityEventRegistryBase.cs
+++ b/src/Libraries/Game.Server/Systems/Events/EntityEventRegistryBase.cs
@@ -1,0 +1,43 @@
+﻿using QuantumCore.API.Game.World;
+using QuantumCore.API.Systems.Events;
+using QuantumCore.Game.Constants;
+
+namespace QuantumCore.Game.Systems.Events;
+
+/// <summary>
+/// This class (and its inheritors) is created to help with readability
+/// by declaring all specific event types as properties or "event slots", therefore
+/// avoiding bloat in the main entity classes, centralizing scheduling configuration,
+/// and discouraging haphazardly scheduling random types of events throughout the code.
+/// </summary>
+public abstract class EntityEventRegistryBase : IDisposable
+{
+    private readonly IEntity _entity;
+    
+    protected EntityEventRegistryBase(IEntity entity)
+    {
+        _entity = entity;
+    }
+
+    public OneShotEvent<IEntity> KnockoutDeath { get; } = new(SchedulingConstants.KnockoutToDeathDelay,
+        target => target.Die());
+
+    public static bool IsScheduled(IEventSlot eventSlot) => eventSlot.EventId.HasValue;
+
+    public long Schedule(ISchedulable<IEntity> schedulable)
+    {
+        schedulable.Cancel();
+
+        var eventId = schedulable.EnqueueEvent(_entity);
+        schedulable.EventId = eventId;
+        return eventId;
+    }
+
+    public static bool Cancel(ISchedulable<IEntity> schedulable) => schedulable.Cancel();
+
+    public virtual void Dispose()
+    {
+        KnockoutDeath.Cancel();
+    }
+
+}

--- a/src/Libraries/Game.Server/Systems/Events/GroundItemEventRegistry.cs
+++ b/src/Libraries/Game.Server/Systems/Events/GroundItemEventRegistry.cs
@@ -1,0 +1,20 @@
+using QuantumCore.API;
+using QuantumCore.Game.Constants;
+
+namespace QuantumCore.Game.Systems.Events;
+
+public sealed class GroundItemEventRegistry(IGroundItem item) : EntityEventRegistry<IGroundItem>(item)
+{
+    public OneShotEvent<IGroundItem> OwnershipExpiry { get; } = new(SchedulingConstants.GroundItemOwnershipLock,
+        groundItem => groundItem.ReleaseOwnership());
+
+    public OneShotEvent<IGroundItem> LifetimeExpiry { get; } = new(SchedulingConstants.GroundItemLifetime,
+        groundItem => groundItem.Map?.DespawnEntity(groundItem));
+
+    public override void Dispose()
+    {
+        Cancel(OwnershipExpiry);
+        Cancel(LifetimeExpiry);
+        base.Dispose();
+    }
+}

--- a/src/Libraries/Game.Server/Systems/Events/MonsterEventRegistry.cs
+++ b/src/Libraries/Game.Server/Systems/Events/MonsterEventRegistry.cs
@@ -1,0 +1,16 @@
+using QuantumCore.API.Game.World;
+using QuantumCore.Game.Constants;
+
+namespace QuantumCore.Game.Systems.Events;
+
+public sealed class MonsterEventRegistry(IEntity monster) : EntityEventRegistry<IEntity>(monster)
+{
+    public OneShotEvent<IEntity> DespawnAfterDeath { get; } = new(SchedulingConstants.MonsterDespawnAfterDeath,
+        m => m.Map?.DespawnEntity(m));
+
+    public override void Dispose()
+    {
+        Cancel(DespawnAfterDeath);
+        base.Dispose();
+    }
+}

--- a/src/Libraries/Game.Server/Systems/Events/OneShotEvent.cs
+++ b/src/Libraries/Game.Server/Systems/Events/OneShotEvent.cs
@@ -1,0 +1,33 @@
+using QuantumCore.API.Game.World;
+using QuantumCore.API.Systems.Events;
+using QuantumCore.Core.Event;
+
+namespace QuantumCore.Game.Systems.Events;
+
+public sealed class OneShotEvent<TEntity>(TimeSpan delay, Action<TEntity> callback) : ISchedulable<TEntity>
+    where TEntity : IEntity
+{
+    public long? EventId { get; set; }
+
+    public long EnqueueEvent(TEntity entity)
+    {
+        return EventSystem.EnqueueEvent(() =>
+        {
+            EventId = null;
+            callback(entity);
+            return TimeSpan.Zero;
+        }, delay);
+    }
+
+    public bool Cancel()
+    {
+        if (!EventId.HasValue)
+        {
+            return false;
+        }
+
+        EventSystem.CancelEvent(EventId.Value);
+        EventId = null;
+        return true;
+    }
+}

--- a/src/Libraries/Game.Server/Systems/Events/PlayerEventRegistry.cs
+++ b/src/Libraries/Game.Server/Systems/Events/PlayerEventRegistry.cs
@@ -1,0 +1,24 @@
+using QuantumCore.API.Core.Event;
+using QuantumCore.API.Game.World;
+using static QuantumCore.Game.Constants.SchedulingConstants;
+
+namespace QuantumCore.Game.Systems.Events;
+
+public sealed class PlayerEventRegistry(IPlayerEntity player, IJobScheduler jobScheduler)
+    : EntityEventRegistry<IPlayerEntity>(player)
+{
+    public SafeLogoutCountdownEvent SafeLogoutCountdown { get; } =
+        new(LOGOUT_WAIT_SECONDS, LOGOUT_COMBAT_WAIT_SECONDS, LOGOUT_COMBAT_GRACE_PERIOD_SECONDS, jobScheduler);
+
+    public OneShotEvent<IPlayerEntity> AutoRespawnInTown { get; } = new(PlayerAutoRespawnDelay,
+        target => {
+            if (target.Dead) target.Respawn(true);
+        });
+
+    public override void Dispose()
+    {
+        Cancel(SafeLogoutCountdown);
+        Cancel(AutoRespawnInTown);
+        base.Dispose();
+    }
+}

--- a/src/Libraries/Game.Server/Systems/Events/RetryableEvent.cs
+++ b/src/Libraries/Game.Server/Systems/Events/RetryableEvent.cs
@@ -1,0 +1,52 @@
+using QuantumCore.API.Game.World;
+using QuantumCore.API.Systems.Events;
+using QuantumCore.Core.Event;
+using Serilog;
+
+namespace QuantumCore.Game.Systems.Events;
+
+// convention: the callback returns false if retry is needed
+public sealed class RetryableEvent<TEntity, TArgs>(
+    TimeSpan retryDelay,
+    Func<TEntity, TArgs, bool> callback,
+    int maxRetries = 99)
+    : ISchedulable<TEntity, TArgs> where TEntity : IEntity
+{
+    public long? EventId { get; set; }
+
+    public long EnqueueEvent(TEntity entity, TArgs arg)
+    {
+        var remainingRetries = maxRetries;
+        return EventSystem.EnqueueEvent(() =>
+        {
+            var succeeded = callback(entity, arg);
+            if (succeeded)
+            {
+                EventId = null;
+                return TimeSpan.Zero;
+            }
+
+            if (remainingRetries-- > 0)
+            {
+                return retryDelay;
+            }
+
+            Log.Error("Retryable event id {Id} for entity {Entity}: exhausted all {MaxRetries} retries",
+                EventId, entity, maxRetries);
+            EventId = null;
+            return TimeSpan.Zero;
+        }, TimeSpan.Zero);
+    }
+
+    public bool Cancel()
+    {
+        if (!EventId.HasValue)
+        {
+            return false;
+        }
+
+        EventSystem.CancelEvent(EventId.Value);
+        EventId = null;
+        return true;
+    }
+}

--- a/src/Libraries/Game.Server/Systems/Events/SafeLogoutCountdownEvent.cs
+++ b/src/Libraries/Game.Server/Systems/Events/SafeLogoutCountdownEvent.cs
@@ -1,0 +1,97 @@
+using QuantumCore.API.Core.Event;
+using QuantumCore.API.Core.Timekeeping;
+using QuantumCore.API.Game.World;
+using QuantumCore.API.Systems.Events;
+using QuantumCore.Core.Event;
+using Serilog;
+
+namespace QuantumCore.Game.Systems.Events;
+
+public sealed class SafeLogoutCountdownEvent(
+    int normalWaitSeconds,
+    int combatWaitSeconds,
+    int combatGraceSeconds,
+    IJobScheduler scheduler)
+    : ISchedulable<IPlayerEntity, SafeLogoutCountdownEvent.Args>
+{
+    public long? EventId { get; set; }
+
+    public readonly record struct Args(
+        string CountdownMessageTemplate,
+        Func<Task> OnCompleteAsync);
+
+    public long EnqueueEvent(IPlayerEntity player, Args args)
+    {
+        var schedulingTime = player.Connection.Server.Clock.Now;
+        var remainingSeconds = ComputeCountdownSeconds(player, schedulingTime);
+
+        return EventSystem.EnqueueEvent(() =>
+        {
+            if (LastCombatActivity(player) > schedulingTime)
+            {
+                player.SendChatInfo("In combat, cancelled.");
+                EventId = null;
+                return TimeSpan.Zero;
+            }
+
+            if (remainingSeconds > 0)
+            {
+                player.SendChatInfo(string.Format(args.CountdownMessageTemplate, remainingSeconds));
+                remainingSeconds--;
+
+                return TimeSpan.FromSeconds(1);
+            }
+
+            scheduler.Schedule(async () =>
+            {
+                try
+                {
+                    await args.OnCompleteAsync();
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "[{CountdownEvent}] Completion callback threw exception for player {Player}",
+                        nameof(SafeLogoutCountdownEvent), player);
+                }
+            });
+            EventId = null;
+            return TimeSpan.Zero;
+        }, TimeSpan.Zero);
+    }
+
+    public bool Cancel()
+    {
+        if (!EventId.HasValue)
+        {
+            return false;
+        }
+
+        EventSystem.CancelEvent(EventId.Value);
+        EventId = null;
+        return true;
+    }
+
+    private int ComputeCountdownSeconds(IPlayerEntity player, ServerTimestamp schedulingTime)
+    {
+        var clock = player.Connection.Server.Clock;
+        if (LastCombatActivity(player) is { } lastCombatTime)
+        {
+            var combatExpirationTime = clock.Advance(lastCombatTime, TimeSpan.FromSeconds(combatGraceSeconds));
+            if (schedulingTime < combatExpirationTime)
+            {
+                return combatWaitSeconds;
+            }
+        } 
+        
+        return normalWaitSeconds;
+    }
+
+    private static ServerTimestamp? LastCombatActivity(IPlayerEntity player)
+    {
+        // TODO: extend for trade, shop open, other interactions
+        return player.Timeline.LatestOf(
+            PlayerTimestampKind.DAMAGE_DEALT,
+            PlayerTimestampKind.DAMAGE_TAKEN,
+            PlayerTimestampKind.USED_SKILL); 
+    }
+}

--- a/src/Libraries/Game.Server/World/AI/StoneBehaviour.cs
+++ b/src/Libraries/Game.Server/World/AI/StoneBehaviour.cs
@@ -87,12 +87,12 @@ public class StoneBehaviour : IBehaviour
             {
                 if (spawnedEntity.Health > 0)
                 {
-                    spawnedEntity.TryScheduleKnockout();
+                    spawnedEntity.TryKnockout();
                 }
             }
 
             _spawnedEntities.Clear();
-            _entity.TryScheduleKnockout();
+            _entity.TryKnockout();
         }
     }
 

--- a/src/Libraries/Game.Server/World/AI/StoneBehaviour.cs
+++ b/src/Libraries/Game.Server/World/AI/StoneBehaviour.cs
@@ -87,11 +87,12 @@ public class StoneBehaviour : IBehaviour
             {
                 if (spawnedEntity.Health > 0)
                 {
-                    spawnedEntity.Die();
+                    spawnedEntity.TryScheduleKnockout();
                 }
             }
 
             _spawnedEntities.Clear();
+            _entity.TryScheduleKnockout();
         }
     }
 

--- a/src/Libraries/Game.Server/World/Entities/Entity.cs
+++ b/src/Libraries/Game.Server/World/Entities/Entity.cs
@@ -5,14 +5,15 @@ using QuantumCore.API.Game.Types;
 using QuantumCore.API.Game.Types.Combat;
 using QuantumCore.API.Game.Types.Entities;
 using QuantumCore.API.Game.World;
-using QuantumCore.Core.Constants;
 using QuantumCore.Core.Utils;
 using QuantumCore.Game.Extensions;
 using QuantumCore.Game.Packets;
+using QuantumCore.Game.Systems.Events;
+using static QuantumCore.Game.Systems.Events.EntityEventRegistryBase;
 
 namespace QuantumCore.Game.World.Entities;
 
-public abstract class Entity : IEntity
+public abstract class Entity : IEntity, IDisposable
 {
     private readonly IAnimationManager _animationManager;
     public uint Vid { get; }
@@ -21,6 +22,7 @@ public abstract class Entity : IEntity
     public uint EntityClass { get; protected set; }
     public EEntityState State { get; protected set; }
     public virtual IEntity? Target { get; set; }
+    protected abstract EntityEventRegistryBase BaseEvents { get; }
 
     public int PositionX
     {
@@ -87,6 +89,8 @@ public abstract class Entity : IEntity
     private bool _positionChanged;
     protected PlayerEntity? LastAttacker { get; private set; }
 
+    protected bool IsIncapacitated => Dead || Health <= 0 || IsScheduled(BaseEvents.KnockoutDeath);
+    
     public Entity(IAnimationManager animationManager, uint vid)
     {
         _animationManager = animationManager;
@@ -136,6 +140,10 @@ public abstract class Entity : IEntity
     {
         if (PositionX == x && PositionY == y) return;
         if (TargetPositionX == x && TargetPositionY == y) return;
+        if (IsIncapacitated)
+        {
+            return;
+        }
 
         var animation =
             _animationManager.GetAnimation(EntityClass, AnimationType.RUN, AnimationSubType.GENERAL);
@@ -197,6 +205,11 @@ public abstract class Entity : IEntity
 
     public void Attack(IEntity victim)
     {
+        if (IsIncapacitated)
+        {
+            return;
+        }
+        
         if (this.PositionIsAttr(EMapAttributes.NON_PVP))
         {
             return;
@@ -205,6 +218,11 @@ public abstract class Entity : IEntity
         if (victim.PositionIsAttr(EMapAttributes.NON_PVP))
         {
             return;
+        }
+
+        if (this is PlayerEntity { Timeline: var attackerTimeline} attacker)
+        {
+            attackerTimeline[PlayerTimestampKind.ATTACK_INITIATED] = attacker.Connection.Server.Clock.Now;
         }
 
         switch (GetBattleType())
@@ -329,16 +347,6 @@ public abstract class Entity : IEntity
         return attack;
     }
 
-    private int CalculateExperience(uint playerLevel)
-    {
-        var baseExp = GetPoint(EPoint.EXPERIENCE);
-        var entityLevel = GetPoint(EPoint.LEVEL);
-
-        var percentage = ExperienceConstants.GetExperiencePercentageByLevelDifference(playerLevel, entityLevel);
-
-        return (int)(baseExp * percentage);
-    }
-
     private void SendDebugDamage(IEntity other, string text)
     {
         if (this is PlayerEntity thisPlayer)
@@ -354,6 +362,10 @@ public abstract class Entity : IEntity
 
     public virtual int Damage(IEntity attacker, EDamageType damageType, int damage)
     {
+        if (IsIncapacitated)
+        {
+            return -1;
+        }
 
         if (this.PositionIsAttr(EMapAttributes.NON_PVP))
         {
@@ -423,18 +435,22 @@ public abstract class Entity : IEntity
         var attackerPlayer = attacker as PlayerEntity;
         if (victimPlayer is not null || attackerPlayer is not null)
         {
-            var damageInfo = new DamageInfo();
-            damageInfo.Vid = Vid;
-            damageInfo.Damage = damage;
-            damageInfo.DamageFlags = damageFlags;
-
-            if (victimPlayer is not null)
+            var damageInfo = new DamageInfo
             {
+                Vid = Vid,
+                Damage = damage,
+                DamageFlags = damageFlags
+            };
+
+            if (victimPlayer is { Timeline: var victimTimeline })
+            {
+                victimTimeline[PlayerTimestampKind.DAMAGE_TAKEN] = victimPlayer.Connection.Server.Clock.Now;
                 victimPlayer.Connection.Send(damageInfo);
             }
 
-            if (attackerPlayer is not null)
+            if (attackerPlayer is { Timeline: var attackerTimeline })
             {
+                attackerTimeline[PlayerTimestampKind.DAMAGE_DEALT] = attackerPlayer.Connection.Server.Clock.Now;
                 attackerPlayer.Connection.Send(damageInfo);
                 LastAttacker = attackerPlayer;
             }
@@ -453,22 +469,34 @@ public abstract class Entity : IEntity
 
         if (Health <= 0)
         {
-            Die();
-            if (Type != EEntityType.PLAYER && attackerPlayer is not null)
-            {
-                var exp = CalculateExperience(attackerPlayer.GetPoint(EPoint.LEVEL));
-                attackerPlayer.AddPoint(EPoint.EXPERIENCE, exp);
-                attackerPlayer.SendPoints();
-            }
+            TryScheduleKnockout();
         }
 
         return damage;
+    }
+    
+    public bool TryScheduleKnockout()
+    {
+        // already dead
+        if (IsScheduled(BaseEvents.KnockoutDeath) || Dead)
+        {
+            return false;
+        }
+
+        Health = 0;
+        Stop();
+        this.SafeBroadcastNearby(new KnockoutCharacter { Vid = Vid });
+        BaseEvents.Schedule(BaseEvents.KnockoutDeath);
+
+        return true;
     }
 
     public virtual void Die()
     {
         Dead = true;
+        Cancel(BaseEvents.KnockoutDeath);
     }
+
 
     public void AddNearbyEntity(IEntity entity)
     {
@@ -490,5 +518,10 @@ public abstract class Entity : IEntity
         {
             action(entity);
         }
+    }
+
+    public virtual void Dispose()
+    {
+        BaseEvents.Dispose();
     }
 }

--- a/src/Libraries/Game.Server/World/Entities/GroundItem.cs
+++ b/src/Libraries/Game.Server/World/Entities/GroundItem.cs
@@ -3,7 +3,9 @@ using QuantumCore.API.Core.Models;
 using QuantumCore.API.Game.Types.Combat;
 using QuantumCore.API.Game.Types.Entities;
 using QuantumCore.API.Game.World;
+using QuantumCore.Game.Extensions;
 using QuantumCore.Game.Packets;
+using QuantumCore.Game.Systems.Events;
 
 namespace QuantumCore.Game.World.Entities;
 
@@ -11,11 +13,15 @@ public class GroundItem : Entity, IGroundItem
 {
     private readonly ItemInstance _item;
     private readonly uint _amount;
-    private readonly string? _ownerName;
+    private string? _ownerName;
 
     public ItemInstance Item => _item;
     public uint Amount => _amount;
     public string? OwnerName => _ownerName;
+
+    private GroundItemEventRegistry Events { get; }
+    protected override EntityEventRegistryBase BaseEvents => Events;
+
 
     public GroundItem(IAnimationManager animationManager, uint vid, ItemInstance item, uint amount,
         string? ownerName = null) : base(animationManager, vid)
@@ -23,6 +29,9 @@ public class GroundItem : Entity, IGroundItem
         _item = item;
         _amount = amount;
         _ownerName = ownerName;
+        Events = new GroundItemEventRegistry(this);
+        Events.Schedule(Events.OwnershipExpiry);
+        Events.Schedule(Events.LifetimeExpiry);
     }
 
     public override EEntityType Type { get; }
@@ -53,6 +62,17 @@ public class GroundItem : Entity, IGroundItem
     public override void HideEntity(IConnection connection)
     {
         connection.Send(new GroundItemRemove {Vid = Vid});
+    }
+
+    public bool ReleaseOwnership()
+    {
+        var hadOwner = _ownerName is not null;
+
+        _ownerName = null;
+        var clearOwnerPacket = new ItemOwnership { Vid = Vid, Player = "" };
+        this.SafeBroadcastNearby(clearOwnerPacket);
+
+        return hadOwner;
     }
 
     public override uint GetPoint(EPoint point)

--- a/src/Libraries/Game.Server/World/Entities/GroundItem.cs
+++ b/src/Libraries/Game.Server/World/Entities/GroundItem.cs
@@ -70,7 +70,7 @@ public class GroundItem : Entity, IGroundItem
 
         _ownerName = null;
         var clearOwnerPacket = new ItemOwnership { Vid = Vid, Player = "" };
-        this.SafeBroadcastNearby(clearOwnerPacket);
+        this.BroadcastNearby(clearOwnerPacket);
 
         return hadOwner;
     }

--- a/src/Libraries/Game.Server/World/Entities/MonsterEntity.cs
+++ b/src/Libraries/Game.Server/World/Entities/MonsterEntity.cs
@@ -247,7 +247,7 @@ public class MonsterEntity : Entity
         base.Die();
         Events.Schedule(Events.DespawnAfterDeath);
 
-        this.SafeBroadcastNearby(new CharacterDead { Vid = Vid });
+        this.BroadcastNearby(new CharacterDead { Vid = Vid });
         // clear target UI for all players targeting this entity
         var clearTargetPacket = new SetTarget { TargetVid = 0 };
         foreach (var targetingPlayer in TargetedBy)

--- a/src/Libraries/Game.Server/World/Entities/MonsterEntity.cs
+++ b/src/Libraries/Game.Server/World/Entities/MonsterEntity.cs
@@ -9,9 +9,12 @@ using QuantumCore.API.Game.Types.Monsters;
 using QuantumCore.API.Game.Types.Players;
 using QuantumCore.API.Game.World;
 using QuantumCore.API.Game.World.AI;
+using QuantumCore.Core.Constants;
 using QuantumCore.Core.Utils;
+using QuantumCore.Game.Extensions;
 using QuantumCore.Game.Packets;
 using QuantumCore.Game.Services;
+using QuantumCore.Game.Systems.Events;
 using QuantumCore.Game.World.AI;
 
 namespace QuantumCore.Game.World.Entities;
@@ -23,6 +26,9 @@ public class MonsterEntity : Entity
     public override EEntityType Type => EEntityType.MONSTER;
     public bool IsStone => Proto.Type == (byte)EEntityType.METIN_STONE;
     public EMonsterLevel Rank => (EMonsterLevel)Proto.Rank;
+    private MonsterEventRegistry Events { get; }
+    protected override EntityEventRegistryBase BaseEvents => Events;
+
 
     public override IEntity? Target
     {
@@ -60,7 +66,6 @@ public class MonsterEntity : Entity
 
     private IBehaviour? _behaviour;
     private bool _behaviourInitialized;
-    private ServerTimestamp? _diedAt;
     private readonly IMap _map;
     private readonly IItemManager _itemManager;
     private IServiceProvider _serviceProvider;
@@ -84,6 +89,7 @@ public class MonsterEntity : Entity
         _serviceProvider = serviceProvider;
         _logger = logger;
         _itemManager = itemManager;
+        Events = new MonsterEventRegistry(this);
         Proto = proto;
         PositionX = x;
         PositionY = y;
@@ -112,22 +118,17 @@ public class MonsterEntity : Entity
     public override void Update(TickContext ctx)
     {
         if (Map is null) return;
-        if (Dead)
-        {
-            if (!_diedAt.HasValue)
-            {
-                _diedAt = ctx.Timestamp;
-            }
-            else if (ctx.ElapsedSince(_diedAt.Value) >= TimeSpan.FromSeconds(5))
-            {
-                Map.DespawnEntity(this);
-            }
-        }
 
         if (!_behaviourInitialized)
         {
             _behaviour?.Init(this);
             _behaviourInitialized = true;
+        }
+        
+        if (IsIncapacitated)
+        {
+            Stop();
+            return;
         }
 
         if (!Dead)
@@ -240,20 +241,43 @@ public class MonsterEntity : Entity
             return;
         }
 
+        CalculateExperience();
         CalculateDrops();
 
         base.Die();
+        Events.Schedule(Events.DespawnAfterDeath);
 
-        var dead = new CharacterDead {Vid = Vid};
-        foreach (var entity in NearbyEntities)
+        this.SafeBroadcastNearby(new CharacterDead { Vid = Vid });
+        // clear target UI for all players targeting this entity
+        var clearTargetPacket = new SetTarget { TargetVid = 0 };
+        foreach (var targetingPlayer in TargetedBy)
         {
-            if (entity is PlayerEntity player)
-            {
-                player.Connection.Send(dead);
-            }
+            targetingPlayer.Connection.Send(clearTargetPacket);
         }
+        TargetedBy.Clear();
     }
+    
+    private void CalculateExperience()
+    {
+        // no exp if no killer
+        if (LastAttacker is not { } killer)
+        {
+            return;
+        }
 
+        var baseExp = GetPoint(EPoint.EXPERIENCE);
+        var entityLevel = GetPoint(EPoint.LEVEL);
+
+        var percentage = ExperienceConstants.GetExperiencePercentageByLevelDifference(
+            killer.GetPoint(EPoint.LEVEL), entityLevel);
+
+        var exp = (int)(baseExp * percentage);
+            
+        // TODO: send animation packet for flying exp orbs
+        killer.AddPoint(EPoint.EXPERIENCE, exp);
+        killer.SendPoints();
+    }
+    
     private void CalculateDrops()
     {
         // no drops if no killer

--- a/src/Libraries/Game.Server/World/Entities/PlayerEntity.cs
+++ b/src/Libraries/Game.Server/World/Entities/PlayerEntity.cs
@@ -847,6 +847,17 @@ public class PlayerEntity : Entity, IPlayerEntity
         }
     }
 
+    protected override bool TryBeginAttack(IEntity victim)
+    {
+        var canAttack = base.TryBeginAttack(victim);
+        if (canAttack)
+        {
+            Timeline[PlayerTimestampKind.ATTACK_INITIATED] = Connection.Server.Clock.Now;
+        }
+
+        return canAttack;
+    }
+
     private async Task Persist()
     {
         await QuickSlotBar.Persist();


### PR DESCRIPTION
1. We have a category of game logic consisting of one-off ("one shot") events, or repeating but still with limited runtime. These are not the best fit for the core Update() loop, and we also don't want to inline random lambdas inside game logic. Therefore, a separate event registry system centralizes all this configuration, and follows the same inheritance hierarchy as the game entities.
2. Timestamps stored directly as class members can grow indefinitely, bloating the classes even more as we add functionality. My solution is an Enum-backed generic timestamp registry that can be reused in many places.
3. Cloned NearbyEntities to avoid being disconnected when battling many mobs.

Implemented retail gameplay features:
- brief "knocked out" phase  before death animation on entities
- safe logout with countdown based on activity status
- cooldown on restart here / restart in town
- restart in town automatically if dead for 3 minutes
- items release ownership lock and expire after defined intervals