### PR TITLE
fix: crash when selecting a character without a skill group

### DIFF
--- a/src/Libraries/Game.Server/Skills/PlayerSkills.cs
+++ b/src/Libraries/Game.Server/Skills/PlayerSkills.cs
@@ -122,11 +122,7 @@ public class PlayerSkills : IPlayerSkills
 
     public async Task LoadAsync()
     {
-        if (_player.Player.SkillGroup.IsDefined())
-        {
-            AssignDefaultActiveSkills();
-        }
-
+        AssignDefaultActiveSkills();
         AssignDefaultPassiveSkills();
 
         var skills = await _repository.GetPlayerSkillsAsync(_player.Player.Id);
@@ -191,10 +187,7 @@ public class PlayerSkills : IPlayerSkills
 
         _skills.Clear();
 
-        if (_player.Player.SkillGroup.IsDefined())
-        {
-            AssignDefaultActiveSkills();
-        }
+        AssignDefaultActiveSkills();
 
         foreach (var subSkill in subSkills)
         {
@@ -452,7 +445,7 @@ public class PlayerSkills : IPlayerSkills
 
         var skillGroup = _player.Player.SkillGroup;
 
-        if (skillGroup.IsDefined()) // if skill group was chosen
+        if (IsSkillGroupChosen(skillGroup))
         {
             for (var i = 0; i < SKILL_COUNT; i++)
             {
@@ -625,8 +618,19 @@ public class PlayerSkills : IPlayerSkills
         _player.Connection.Send(levels);
     }
 
+    /// <summary>
+    /// Whether the player actually picked a skill group. <see cref="ESkillGroup.UNKNOWN"/> is a
+    /// defined enum value, so <c>IsDefined()</c> on its own does not answer this.
+    /// </summary>
+    private static bool IsSkillGroupChosen(ESkillGroup skillGroup) =>
+        skillGroup != ESkillGroup.UNKNOWN && skillGroup.IsDefined();
+
     private void AssignDefaultActiveSkills()
     {
+        // A skill group is only picked from MINIMUM_LEVEL onwards, so a fresh character has
+        // none yet and there are no default active skills to assign.
+        if (!IsSkillGroupChosen(_player.Player.SkillGroup)) return;
+
         for (var i = 0; i < SKILL_COUNT; i++)
         {
             var skill = SkillList[(int)_player.Player.PlayerClass.GetClass(), (byte)_player.Player.SkillGroup - 1, i];


### PR DESCRIPTION
## Problem

Every newly created character is unable to enter the game. Selecting one closes the connection, and the server logs:

```
System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at QuantumCore.Game.Skills.PlayerSkills.AssignDefaultActiveSkills() in PlayerSkills.cs:line 632
   at QuantumCore.Game.Skills.PlayerSkills.LoadAsync() in PlayerSkills.cs:line 127
   at QuantumCore.Game.World.Entities.PlayerEntity.LoadAsync() in PlayerEntity.cs:line 174
   at QuantumCore.Game.PlayerFactory.CreatePlayerAsync(...) in PlayerFactory.cs:line 24
   at QuantumCore.Game.PacketHandlers.Select.SelectGameCharacterHandler.ExecuteAsync(...) line 47
```

## Root cause

`ESkillGroup.UNKNOWN` is `0` and is a **defined** enum member, so `IsDefined()` returns `true` for it:

```csharp
if (_player.Player.SkillGroup.IsDefined())   // passes for UNKNOWN
{
    AssignDefaultActiveSkills();
}
```

`AssignDefaultActiveSkills` then does:

```csharp
SkillList[(int)_player.Player.PlayerClass.GetClass(), (byte)_player.Player.SkillGroup - 1, i]
```

With `SkillGroup == UNKNOWN` that second index is `(byte)0 - 1 == -1`.

A character only picks a skill group from `MINIMUM_LEVEL` onwards, so every freshly created character has `SkillGroup == UNKNOWN` and hits this. Characters that already have a skill group are unaffected, which is why this does not show up on an established account.

`CanUse` indexes `SkillList` the same way behind the same `IsDefined()` check — its `// if skill group was chosen` comment states the intent that `IsDefined()` does not actually express.

## Reproduction

1. Start a server and log in
2. Create a character in an empty slot
3. Select it

The connection closes instead of moving to the loading phase.

## Fix

- Added `IsSkillGroupChosen`, which is what the original `// if skill group was chosen` comment meant. It keeps the existing `IsDefined()` check so out of range values are still rejected, and additionally excludes `UNKNOWN`.
- Moved the guard **into** `AssignDefaultActiveSkills` rather than repeating it at each call site. All three callers (`LoadAsync`, `ResetSkills`, `SetSkillGroup`) are now covered — `SetSkillGroup` previously had no guard at all and would crash when passed `UNKNOWN`, which its own check explicitly allows. The now redundant guards at the call sites were removed.
- `CanUse` uses the same helper.

## Notes

- `PlayerSkills.cs` has two more `IsDefined()` checks on `SkillGroup` (in `SkillUp` and `IsUsableSkillMotionAttack`) that treat `UNKNOWN` as chosen. They do not index `SkillList`, so they do not crash, and I left them alone to keep this change focused. Happy to address them separately if you would like them to be consistent.
- I did not add a regression test. `PlayerSkills` takes a concrete `PlayerEntity`, which needs 11 dependencies plus an `IServiceProvider` that resolves `IItemRepository`, and there is no existing test that constructs one. Building that setup for a single assertion felt like it would add a brittle test with no precedent in the suite — but if you would like that pattern established, I am glad to add it.

## Testing

- `dotnet test` — 237/237 passing
- Verified manually against a running server: both a character created before the fix and a freshly created one now reach the game phase; an existing character with a skill group still behaves as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
