### PR TITLE
fix: off by one size field for dynamic packets with a sequence

### DIFF
--- a/src/Core.Networking.Generators/SerializeGenerator.cs
+++ b/src/Core.Networking.Generators/SerializeGenerator.cs
@@ -35,8 +35,12 @@ internal class SerializeGenerator
             for (var index = 0; index < fields.Length; index++)
             {
                 var field = fields[index];
+                // The size field holds the packet size without the trailing sequence byte -
+                // that is what the deserializer subtracts its static size from - while
+                // GetSize() has to include it so the whole packet gets written.
+                var sizeExpression = hasSequence ? "(this.GetSize() - 1)" : "this.GetSize()";
                 var fieldExpression = fields.Any(x => x.SizeFieldName == field.Name)
-                    ? "this.GetSize()"
+                    ? sizeExpression
                     : $"this.{field.Name}";
 
                 if (subHeader is not null && subHeader.Value.Position == index)

--- a/src/Tests/Core.Networking.Generators.Tests/SerializerGeneratorTests.cs
+++ b/src/Tests/Core.Networking.Generators.Tests/SerializerGeneratorTests.cs
@@ -1347,8 +1347,8 @@ namespace QuantumCore.Game.Packets {
         public void Serialize(byte[] bytes, in int offset = 0)
         {
             bytes[offset + 0] = 0x03;
-            bytes[offset + 1] = (byte)(this.GetSize() >> 0);
-            bytes[offset + 2] = (byte)(this.GetSize() >> 8);
+            bytes[offset + 1] = (byte)((this.GetSize() - 1) >> 0);
+            bytes[offset + 2] = (byte)((this.GetSize() - 1) >> 8);
             bytes[offset + 3] = this.MessageType;
             bytes.WriteString(this.Message, offset + 4, (int)this.Size + 1);
             bytes[offset + 4 + this.Message.Length] = default;

--- a/src/Tests/Core.Tests/NetworkingTests.cs
+++ b/src/Tests/Core.Tests/NetworkingTests.cs
@@ -91,7 +91,7 @@ public class NetworkingTests
     {
         var obj = new ChatIncoming { MessageType = ChatMessageType.NORMAL, Message = "Hello New World!" };
         var size = obj.GetSize();
-        var bytes = new byte[size + 1]; // + 1 due to sequence
+        var bytes = new byte[size]; // GetSize already covers the sequence byte
         obj.Serialize(bytes);
 
         using var stream = new MemoryStream(bytes);


### PR DESCRIPTION
## Problem

For a packet that has both a dynamic size field and `Sequence = true`, the generated `Serialize` and `Deserialize` do not agree: reading back what was written consumes one byte too many, and `PacketReader` then reads the next packet's header as the sequence byte.

Concretely, for `ChatIncoming` with a 16 character message the generator produces:

```csharp
public void Serialize(byte[] bytes, in int offset = 0)
{
    bytes[offset + 0] = 0x03;
    bytes[offset + 1] = (byte)(this.GetSize() >> 0);   // Message.Length + 6
    ...
}

public ushort GetSize()
{
    return (ushort)(5 + this.Message.Length + 1);      // includes the sequence byte
}

// deserialize
var __Size = await stream.ReadValueFromStreamAsync<UInt16>(buffer) - 4;   // Message.Length + 2
var __Message = await stream.ReadStringFromStreamAsync(buffer, (int)__Size);
```

`GetSize()` includes the trailing sequence byte, since that byte is part of what gets written. The deserializer subtracts only the header plus the static fields (`typeStaticSize + 1`), never the sequence byte, so it reads `Message.Length + 2` bytes for the string: message, null terminator **and** the sequence byte. `PacketReader` then reads one more byte for the sequence, which is already the next packet's header.

## Reproduction

Send two chat packets back to back. The second one fails with, for example:

```
System.NotImplementedException: Received unknown header 0x0C
```

`0x0C` is the low byte of the second packet's size field, read as a header after its real header was swallowed.

## Fix

Write `GetSize() - 1` into the size field when the packet has a sequence, so the value means "packet size without the trailing sequence byte" — which is what the deserializer already assumes.

## Scope

Only packets with **both** a dynamic size field and `Sequence = true` are affected: `ChatIncoming` and `WhisperIncoming`. I diffed the full generated output before and after, and every other packet is byte for byte identical.

Both are `EDirection.INCOMING`, so the server only ever deserializes them and normal gameplay was never affected. The mismatch only shows up in code that *writes* these packets — tests, tooling, or anything implementing a client against these types.

## Test change

`NetworkingTests.DynamicAsync` allocated one byte more than `GetSize()`:

```csharp
var bytes = new byte[size + 1]; // + 1 due to sequence
```

That padding compensated for exactly this over-read. With serialize and deserialize agreeing, the extra byte is left in the stream and read as a second packet, so it has been removed. The expected output in `Class_WithDynamicStringAndSequence` was updated to match the new size field expression.

## Testing

- `dotnet test` — 237/237 passing
- Verified against a running server: chat round trips correctly and consecutive chat packets no longer desync the reader

🤖 Generated with [Claude Code](https://claude.com/claude-code)
