### PR TITLE
fix: crash when a monster with a drop group dies

### DIFF
--- a/src/Libraries/Game.Server/Drops/MonsterDropContainer.cs
+++ b/src/Libraries/Game.Server/Drops/MonsterDropContainer.cs
@@ -63,8 +63,10 @@ public class MonsterItemGroup : MonsterDropContainer
             }
         }
 
-        var distance = _probabilities.Count - lowerBound;
-        return distance;
+        // The index of the element we stopped at - not the distance from it to the end, which
+        // equals the element count whenever the first entry already matches and would then be
+        // one past the last valid index.
+        return lowerBound;
     }
 
     public Drop? GetDrop()

--- a/src/Tests/Game.Tests/DropTests.cs
+++ b/src/Tests/Game.Tests/DropTests.cs
@@ -1,0 +1,26 @@
+using AwesomeAssertions;
+using QuantumCore.Game.Drops;
+
+namespace Game.Tests;
+
+public class DropTests
+{
+    [Fact]
+    public void DropIsPickedFromWithinTheGroup()
+    {
+        var group = new MonsterItemGroup();
+        group.AddDrop(itemProtoId: 1, count: 1, dropChance: 1, rareDropChance: 0);
+
+        // the pick is random, so try often enough to cover every branch
+        for (var i = 0; i < 100; i++)
+        {
+            group.GetDrop().Should().NotBeNull();
+        }
+    }
+
+    [Fact]
+    public void EmptyGroupDropsNothing()
+    {
+        new MonsterItemGroup().GetDrop().Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Problem

Killing a monster that has a drop group throws, which aborts the drop calculation and drops the attacker's connection:

```
System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')
   at System.Collections.Generic.List`1.get_Item(Int32 index)
   at QuantumCore.Game.Drops.MonsterItemGroup.GetDrop()
   at QuantumCore.Game.Services.DropProvider.CalculateMobDropItemGroupItems(IPlayerEntity player, MonsterEntity monster, Int32 delta, Int32 range)
   at QuantumCore.Game.World.Entities.MonsterEntity.CalculateDrops()
   at QuantumCore.Game.World.Entities.MonsterEntity.Die()
   at QuantumCore.Game.World.Entities.Entity.Damage(IEntity attacker, EDamageType damageType, Int32 damage)
   at QuantumCore.Game.World.Entities.Entity.MeleeAttack(IEntity victim)
   at QuantumCore.Game.PacketHandlers.Game.AttackHandler.ExecuteAsync(GamePacketContext`1 ctx, CancellationToken token)
```

Because it escapes from `Die`, `CalculateDrops` never reaches `AddGroundItem`, so nothing at all is dropped even from the sources that were computed successfully.

## Root cause

```csharp
public int GetOneIndex()
{
    var n = CoreRandom.GenerateInt32(0, _probabilities.Count + 1);
    var lowerBound = 0;
    for (var i = 0; i < _probabilities.Count; i++)
    {
        if (_probabilities[i] >= n) { lowerBound = i; break; }
    }

    var distance = _probabilities.Count - lowerBound;
    return distance;
}

public Drop? GetDrop()
{
    if (IsEmpty) return null;

    var index = GetOneIndex();
    return _drops[index];   // index can equal _drops.Count
}
```

The method is named and used as an index, but it returns the distance from the matched entry to the end of the list. When the first entry already matches, `lowerBound` is `0` and the returned distance equals the element count, which is exactly one past the last valid index.

This reads like a translation of `distance(begin, lower_bound(...))`, where the distance from `begin` to the found element *is* its index — so the subtraction is the wrong way round.

A group with a single entry hits this on every call: `n` is drawn from `[0, 2)` and the only probability always compares `>=`, so `lowerBound` is always `0` and `_drops[1]` always throws.

## Fix

Return `lowerBound`, the index of the entry the loop stopped at. That is always within range and preserves the intended "first entry not below `n`" selection.

## Testing

- Added `DropTests`, covering a single entry group (fails on `main` with the exception above) and an empty group
- `dotnet test` — 239/239 passing
- Verified against a running server: monsters with a drop group now die without throwing, and their loot reaches the ground as `GroundItemAdd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
