### PR TITLE
feat: open container items and hand out their contents

### DIFF
--- a/src/Libraries/Game.Server/Extensions/ServiceExtensions.cs
+++ b/src/Libraries/Game.Server/Extensions/ServiceExtensions.cs
@@ -48,6 +48,7 @@ public static class ServiceExtensions
         services.AddLoadable<IExperienceManager, ExperienceManager>();
         services.AddLoadable<IQuestManager, QuestManager>();
         services.AddLoadable<IDropProvider, DropProvider>();
+        services.AddLoadable<ISpecialItemProvider, SpecialItemProvider>();
         services.AddLoadable<INpcShopProvider, TsvShopProvider>();
         services.AddLoadable<ISkillManager, SkillManager>();
         services.AddLoadable<IWorld, World.World>();

--- a/src/Libraries/Game.Server/PacketHandlers/Game/ItemUseHandler.cs
+++ b/src/Libraries/Game.Server/PacketHandlers/Game/ItemUseHandler.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using QuantumCore.API;
+using QuantumCore.API.Core.Models;
 using QuantumCore.API.Extensions;
 using QuantumCore.API.Game.Types.Items;
 using QuantumCore.API.Game.Types.Skills;
@@ -8,6 +9,8 @@ using QuantumCore.API.Packets;
 using QuantumCore.API.PluginTypes;
 using QuantumCore.Core.Utils;
 using QuantumCore.Game.Extensions;
+using QuantumCore.Game.Persistence;
+using QuantumCore.Game.Services;
 
 namespace QuantumCore.Game.PacketHandlers.Game;
 
@@ -16,12 +19,17 @@ internal class ItemUseHandler : IGamePacketHandler<ItemUse>
     private readonly IItemManager _itemManager;
     private readonly ILogger<ItemUseHandler> _logger;
     private readonly SkillsOptions _skillsOptions;
+    private readonly ISpecialItemProvider _specialItemProvider;
+    private readonly IItemRepository _itemRepository;
 
-    public ItemUseHandler(IItemManager itemManager, ILogger<ItemUseHandler> logger, IOptions<GameOptions> gameOptions)
+    public ItemUseHandler(IItemManager itemManager, ILogger<ItemUseHandler> logger, IOptions<GameOptions> gameOptions,
+        ISpecialItemProvider specialItemProvider, IItemRepository itemRepository)
     {
         _itemManager = itemManager;
         _logger = logger;
         _skillsOptions = gameOptions.Value.Skills;
+        _specialItemProvider = specialItemProvider;
+        _itemRepository = itemRepository;
     }
 
     public async Task ExecuteAsync(GamePacketContext<ItemUse> ctx, CancellationToken token = default)
@@ -99,6 +107,40 @@ internal class ItemUseHandler : IGamePacketHandler<ItemUse>
                     player.SendRemoveItem(ctx.Packet.Window, ctx.Packet.Position);
                     player.SendItem(item);
                 }
+            }
+        }
+        // Container items - chests and the like - hand out one of the rewards listed for them
+        // in special_item_group.txt and are consumed in the process.
+        else if (_specialItemProvider.Roll(item.ItemId) is { } reward)
+        {
+            var instance = new ItemInstance
+            {
+                ItemId = reward.ItemProtoId, Count = reward.Count, PlayerId = player.Player.Id
+            };
+
+            if (!await player.Inventory.PlaceItemAsync(instance))
+            {
+                player.SendChatInfo("Cannot open this while the inventory is full");
+                return;
+            }
+
+            await instance.PersistAsync(_itemRepository);
+            player.SendItem(instance);
+
+            _logger.LogDebug("{Player} opened {Container} and received {Item} x{Count}", player.Name, item.ItemId,
+                reward.ItemProtoId, reward.Count);
+
+            if (item.Count > 1)
+            {
+                // only one of the stack is opened
+                item.Count -= 1;
+                await item.PersistAsync(_itemRepository);
+                player.SendItem(item);
+            }
+            else
+            {
+                player.RemoveItem(item);
+                player.SendRemoveItem(ctx.Packet.Window, ctx.Packet.Position);
             }
         }
         // Skills related

--- a/src/Libraries/Game.Server/Services/ISpecialItemProvider.cs
+++ b/src/Libraries/Game.Server/Services/ISpecialItemProvider.cs
@@ -1,0 +1,26 @@
+using System.Collections.Immutable;
+
+namespace QuantumCore.Game.Services;
+
+/// <summary>
+/// One possible reward of a container item, with the weight it is picked by.
+/// </summary>
+public record struct SpecialItemEntry(uint ItemProtoId, byte Count, uint Weight);
+
+/// <summary>
+/// The contents of container items - chests and the like - as defined by
+/// <c>special_item_group.txt</c>.
+/// </summary>
+public interface ISpecialItemProvider
+{
+    /// <summary>
+    /// Everything the given container can yield. Empty when the item is not a container.
+    /// </summary>
+    ImmutableArray<SpecialItemEntry> GetPossibleContents(uint containerItemProtoId);
+
+    /// <summary>
+    /// Picks one reward at random, weighted by the entries' weights.
+    /// Null when the item is not a container or its group has no usable entry.
+    /// </summary>
+    SpecialItemEntry? Roll(uint containerItemProtoId);
+}

--- a/src/Libraries/Game.Server/Services/SpecialItemProvider.cs
+++ b/src/Libraries/Game.Server/Services/SpecialItemProvider.cs
@@ -1,0 +1,120 @@
+using System.Collections.Frozen;
+using System.Collections.Immutable;
+using System.Text;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
+using QuantumCore.API;
+using QuantumCore.Core.Utils;
+
+namespace QuantumCore.Game.Services;
+
+/// <summary>
+/// Reads <c>special_item_group.txt</c>, which lists what container items can yield:
+/// <code>
+/// Group SomeChest
+/// {
+///     Vnum    10000
+///     1       72001   1   1
+/// }
+/// </code>
+/// Each content line is index, item proto id, count and weight.
+/// </summary>
+internal sealed class SpecialItemProvider : ISpecialItemProvider, ILoadable
+{
+    private const string FILE = "special_item_group.txt";
+
+    private readonly IFileProvider _fileProvider;
+    private readonly ILogger<SpecialItemProvider> _logger;
+
+    // the game data files are written in the original korean encoding
+    private readonly Encoding _fileEncoding;
+    private FrozenDictionary<uint, ImmutableArray<SpecialItemEntry>> _groups =
+        FrozenDictionary<uint, ImmutableArray<SpecialItemEntry>>.Empty;
+
+    public SpecialItemProvider(IFileProvider fileProvider, ILogger<SpecialItemProvider> logger)
+    {
+        _fileProvider = fileProvider;
+        _logger = logger;
+
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance); // register korean locale
+        _fileEncoding = Encoding.GetEncoding("EUC-KR");
+    }
+
+    public async Task LoadAsync(CancellationToken cancellationToken = default)
+    {
+        var file = _fileProvider.GetFileInfo(FILE);
+        if (!file.Exists)
+        {
+            _logger.LogWarning("{Path} does not exist, container item contents not loaded", FILE);
+            return;
+        }
+
+        await using var fs = file.CreateReadStream();
+        using var sr = new StreamReader(fs, _fileEncoding);
+
+        var groups = new Dictionary<uint, ImmutableArray<SpecialItemEntry>>();
+        uint? vnum = null;
+        var entries = new List<SpecialItemEntry>();
+
+        while (await sr.ReadLineAsync(cancellationToken) is { } line)
+        {
+            var parts = line.Split('\t', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (parts.Length == 0) continue;
+
+            if (parts[0] == "}")
+            {
+                if (vnum is not null && entries.Count > 0)
+                {
+                    groups[vnum.Value] = [.. entries];
+                }
+
+                vnum = null;
+                entries.Clear();
+                continue;
+            }
+
+            if (parts[0].Equals("Vnum", StringComparison.OrdinalIgnoreCase))
+            {
+                if (parts.Length > 1 && uint.TryParse(parts[1], out var parsed)) vnum = parsed;
+                continue;
+            }
+
+            // content line: index, item proto id, count, weight - anything else (Group, Type,
+            // the opening brace) carries no reward
+            if (parts.Length < 4) continue;
+            if (!uint.TryParse(parts[1], out var itemId)) continue;
+            if (!byte.TryParse(parts[2], out var count)) continue;
+            if (!uint.TryParse(parts[3], out var weight)) continue;
+            if (itemId == 0 || weight == 0) continue;
+
+            entries.Add(new SpecialItemEntry(itemId, count == 0 ? (byte)1 : count, weight));
+        }
+
+        _groups = groups.ToFrozenDictionary();
+        _logger.LogDebug("Found contents for {Count:D} container items", groups.Count);
+    }
+
+    public ImmutableArray<SpecialItemEntry> GetPossibleContents(uint containerItemProtoId)
+    {
+        return _groups.TryGetValue(containerItemProtoId, out var entries) ? entries : [];
+    }
+
+    public SpecialItemEntry? Roll(uint containerItemProtoId)
+    {
+        var entries = GetPossibleContents(containerItemProtoId);
+        if (entries.IsEmpty) return null;
+
+        var total = entries.Sum(x => (long)x.Weight);
+        if (total <= 0) return null;
+
+        var roll = CoreRandom.GenerateInt32(0, (int)Math.Min(total, int.MaxValue));
+        var cumulative = 0L;
+        foreach (var entry in entries)
+        {
+            cumulative += entry.Weight;
+            if (roll < cumulative) return entry;
+        }
+
+        return entries[^1];
+    }
+}

--- a/src/Tests/Game.Tests/Fixtures/special_item_group.txt
+++ b/src/Tests/Game.Tests/Fixtures/special_item_group.txt
@@ -1,0 +1,21 @@
+Group FirstChest
+{
+	Vnum	9001
+	1	5001	1	70
+	2	5002	3	30
+}
+
+Group SecondChest
+{
+	Vnum	9002
+	type	Pct
+	1	5003	1	100
+}
+
+Group AttributeGroup
+{
+	Vnum	9003
+	type	ATTR
+	1	66	30
+	2	78	20
+}

--- a/src/Tests/Game.Tests/Game.Tests.csproj
+++ b/src/Tests/Game.Tests/Game.Tests.csproj
@@ -30,6 +30,9 @@
     <None Update="Fixtures\mob_proto">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Fixtures\special_item_group.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/Tests/Game.Tests/SpecialItemProviderTests.cs
+++ b/src/Tests/Game.Tests/SpecialItemProviderTests.cs
@@ -1,0 +1,78 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.FileProviders.Physical;
+using NSubstitute;
+using QuantumCore.API;
+using QuantumCore.Game.Services;
+
+namespace Game.Tests;
+
+public class SpecialItemProviderTests
+{
+    private readonly ISpecialItemProvider _provider;
+
+    public SpecialItemProviderTests()
+    {
+        _provider = new ServiceCollection()
+            .AddLogging()
+            .AddSingleton<ISpecialItemProvider, SpecialItemProvider>()
+            .AddSingleton(_ =>
+            {
+                var mock = Substitute.For<IFileProvider>();
+                mock.GetFileInfo(Arg.Any<string>()).ReturnsForAnyArgs(call =>
+                    new PhysicalFileInfo(new FileInfo(Path.Combine("Fixtures", call.Arg<string>()!))));
+                return mock;
+            })
+            .BuildServiceProvider()
+            .GetRequiredService<ISpecialItemProvider>();
+    }
+
+    private async Task LoadAsync()
+    {
+        await ((ILoadable)_provider).LoadAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task ReadsTheContentsOfAContainerAsync()
+    {
+        await LoadAsync();
+
+        _provider.GetPossibleContents(9001).Should().BeEquivalentTo([
+            new SpecialItemEntry(5001, 1, 70),
+            new SpecialItemEntry(5002, 3, 30)
+        ]);
+    }
+
+    [Fact]
+    public async Task IgnoresAttributeGroupsAsync()
+    {
+        await LoadAsync();
+
+        // ATTR groups list random bonuses rather than items, so they yield no rewards
+        _provider.GetPossibleContents(9003).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ReportsNothingForAnItemThatIsNoContainerAsync()
+    {
+        await LoadAsync();
+
+        _provider.GetPossibleContents(1234).Should().BeEmpty();
+        _provider.Roll(1234).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AlwaysRollsAnEntryOfTheContainerAsync()
+    {
+        await LoadAsync();
+
+        var allowed = _provider.GetPossibleContents(9001);
+
+        // the pick is random, so try often enough to cover every branch
+        for (var i = 0; i < 100; i++)
+        {
+            _provider.Roll(9001).Should().NotBeNull().And.BeOneOf([.. allowed.Cast<SpecialItemEntry?>()]);
+        }
+    }
+}


### PR DESCRIPTION
## What this adds

Using a container item - a chest and the like - currently does nothing. `ItemUseHandler` knows about equipping, unequipping, skill books and soul stones, so a right click on a chest is received, matches no branch and is silently dropped.

This adds `ISpecialItemProvider`, which reads what containers can yield from `special_item_group.txt`, and wires it into `ItemUseHandler`.

## The data

Each group maps a container's vnum to the items it can yield, one line per entry with a weight:

```
Group SomeChest
{
    Vnum    9001
    1       5001    1   70
    2       5002    3   30
}
```

The same file also holds `ATTR` groups, which list random bonuses rather than items and have one column fewer. Those carry no reward, so the parser skips them.

## Behaviour

Opening rolls one entry weighted by the entry weights, places it in the inventory and consumes the container - a single one of it when the player is holding a stack. When the inventory has no room the open is refused and the container is kept, rather than being eaten for nothing.

`GetPossibleContents` is part of the interface too, so what a container may yield can be shown without opening it.

## Depends on #539

Without that fix this crashes in practice rather than in theory: container rewards are random, and any reward carrying the `UNIQUE` wear flag takes the connection down inside `Inventory.PlaceItemAsync`. That is how I found the gap in #539 in the first place.

## Testing

- `SpecialItemProviderTests` covers parsing a group, skipping `ATTR` groups, reporting nothing for an item that is no container, and that a roll always returns one of the group's entries. It runs against a small synthetic fixture rather than the real data file.
- `dotnet test` — 241/241 passing
- Verified against a running server: `/item 50006` then using it logs `opened 50006 and received 50300 x1`, with the reward in the inventory and the container gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
